### PR TITLE
Correction/additions to recipes for Smooth_Stone

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -68,6 +68,7 @@ factories:
         amount: 512
     recipes:
      - smelt_stone
+     - smelt_smooth_stone
      - smelt_glass
      - smelt_netherrack
      - smelt_red_netherbrick
@@ -118,6 +119,7 @@ factories:
      - make_redstone_lamp
      - pack_ice
      - pack_blue_ice
+     - make_stone_slab
      - make_smooth_stone_slab
      - make_smooth_sandstone_slab
      - make_smooth_quartz_slab
@@ -737,6 +739,18 @@ recipes:
       stone:
         material: STONE
         amount: 96
+  smelt_smooth_stone:
+    production_time: 4s
+    name: Smelt Smooth Stone
+    type: PRODUCTION
+    input:
+      cobblestone:
+        material: STONE
+        amount: 64
+    output:
+      stone:
+        material: SMOOTH_STONE
+        amount: 80
   cook_beef:
     production_time: 4s
     name: Cook Beef
@@ -5036,10 +5050,10 @@ recipes:
       blue_ice:
         material: BLUE_ICE
         amount: 64
-  make_smooth_stone_slab:
+  make_stone_slab:
     forceInclude: true
     type: PRODUCTION
-    name: Make Smooth Stone Slab
+    name: Make Stone Slab
     production_time: 4s
     input:
       stone:
@@ -5048,9 +5062,20 @@ recipes:
     output:
       stone_slab:
         material: STONE_SLAB
+        amount: 128
+  make_smooth_stone_slab:
+    forceInclude: true
+    type: PRODUCTION
+    name: Make Smooth Stone Slab
+    production_time: 4s
+    input:
+      stone:
+        material: SMOOTH_STONE
         amount: 64
-        lore:
-          - Smooth double slab
+    output:
+      stone_slab:
+        material: SMOOTH_STONE_SLAB
+        amount: 128
   make_smooth_sandstone_slab:
     forceInclude: true
     type: PRODUCTION


### PR DESCRIPTION
Added:
-Recipes
    -smelt smooth stone
    -make smooth stone slab

Renamed/Corrected:
- Recipes that claimed they created `smooth_stone`, that actually created `stone` were retitled, and the involved "make" functions were corrected.
- Because `double_stone_slab:8` blocks no longer exist, and are now functionally the same thing as `smooth_stone`, the lore of `double block` was removed, and the output doubled, to give a equal number of smooth stone slabs as crafting by hand.
- Because `double_stone_slab:8` was essentially two smooth stone slabs, the corresponding recipe for `stone_slabs` would have just been a regular `stone` block, so the lore of `double block` was removed.

Balance:
- Gave a 1.25x multiplier for smooth stone when smelting. (64 in:80 out)
- Because the original slab recipe assumed you would be creating a double block, rather than individual half slabs, the I/O ratio was 1:1. In order to match vanilla, the output was increased to 128.