### PR TITLE
New Recipes to Fix Sapling Conversions

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -408,10 +408,15 @@ factories:
      - dirt_to_podzol
      - dirt_to_mycelium
      - sapling_to_spruce
+     - spruce_to_sapling
      - sapling_to_birch
+     - birch_to_sapling
      - sapling_to_jungle
+     - jungle_to_sapling
      - sapling_to_acacia
+     - acacia_to_sapling
      - sapling_to_dark_oak
+     - dark_oak_to_sapling
      - make_mushroom_brown
      - make_mushroom_red
      - make_mushroom_stem
@@ -1758,60 +1763,120 @@ recipes:
     name: Convert Oak Sapling to Spruce
     type: PRODUCTION
     input:
-      sapling:
+      oak_sapling:
         material: OAK_SAPLING
         amount: 32
     output:
       spruce_sapling:
         material: SPRUCE_SAPLING
         amount: 32
+  spruce_to_sapling:
+    production_time: 4s
+    name: Convert Spruce Sapling to Oak
+    type: PRODUCTION
+    input:
+      spruce_sapling:
+        material: SPRUCE_SAPLING
+        amount: 32
+    output:
+      oak_sapling:
+        material: OAK_SAPLING
+        amount: 32
   sapling_to_birch:
     production_time: 4s
     name: Convert Oak Sapling to Birch
     type: PRODUCTION
     input:
-      sapling:
+      oak_sapling:
         material: OAK_SAPLING
         amount: 32
     output:
       birch_sapling:
         material:  BIRCH_SAPLING
         amount: 32
+  birch_to_sapling:
+    production_time: 4s
+    name: Convert Birch Sapling to Oak
+    type: PRODUCTION
+    input:
+      oak_sapling:
+        material:  OAK_SAPLING
+        amount: 32
+    output:
+      birch_sapling:
+        material: BIRCH_SAPLING
+        amount: 32
   sapling_to_jungle:
     production_time: 4s
     name: Convert Oak Sapling to Jungle
     type: PRODUCTION
     input:
-      sapling:
+      oak_sapling:
         material: OAK_SAPLING
         amount: 32
     output:
       jungle_sapling:
         material: JUNGLE_SAPLING
         amount: 32
+  jungle_to_sapling:
+    production_time: 4s
+    name: Convert Jungle Sapling to Oak
+    type: PRODUCTION
+    input:
+      jungle_sapling:
+        material: JUNGLE_SAPLING
+        amount: 32
+    output:
+      oak_sapling:
+        material: OAK_SAPLING
+        amount: 32
   sapling_to_acacia:
     production_time: 4s
     name: Convert Oak Sapling to Acacia
     type: PRODUCTION
     input:
-      sapling:
+      oak_sapling:
         material: OAK_SAPLING
         amount: 32
     output:
       acacia_sapling:
         material: ACACIA_SAPLING
         amount: 32
+  acacia_to_sapling:
+    production_time: 4s
+    name: Convert Acacia Sapling to Oak
+    type: PRODUCTION
+    input:
+      acacia_sapling:
+        material: ACACIA_SAPLING
+        amount: 32
+    output:
+      oak_sapling:
+        material: OAK_SAPLING
+        amount: 32
   sapling_to_dark_oak:
     production_time: 4s
     name: Convert Oak Sapling to Dark Oak
     type: PRODUCTION
     input:
-      sapling:
+      oak_sapling:
         material: OAK_SAPLING
         amount: 32
     output:
       dark_oak_sapling:
         material: DARK_OAK_SAPLING
+        amount: 32
+  dark_oak_to_sapling:
+    production_time: 4s
+    name: Convert Dark Oak Sapling to Oak
+    type: PRODUCTION
+    input:
+      oak_sapling:
+        material: DARK_OAK_SAPLING
+        amount: 32
+    output:
+      oak_sapling:
+        material: OAK_SAPLING
         amount: 32
   dye_clay_white:
     production_time: 4s


### PR DESCRIPTION
I just made a new recipe with the same ratios to allow oak to be converted to each type of sapling, to make the behavior consistent with what people experienced in 1.12.

If the change was intentional, feel free to let me know. But it seemed to just be another issue with block variants being converted from damage values to actual independent blocks.

If there is a way to get the same functionality we had in 1.12.2, where you could just put any sapling in, and it would auto convert it to oak, without having to select a specific recipe, that'd be ideal, but as far as I know, because there are no more damage value varients like there used to be, that isn't currently possible (Within the limits of my admittedly shallow understanding of factorymod)

Charcoal also likely has this same issue, because currently, it you can only convert oak into charcoal from what I'm hearing from people in the server. If I fix that today, I will make it as a new pull request however.