### PR TITLE
Charcoal Factory Corrections

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -85,7 +85,12 @@ factories:
         material: CHARCOAL
         amount: 512
     recipes:
-     - charcoal_from_logs
+     - charcoal_from_oak_log
+     - charcoal_from_spruce_log
+     - charcoal_from_birch_log
+     - charcoal_from_jungle_log
+     - charcoal_from_acacia_log
+     - charcoal_from_dark_oak_log
      - charcoal_from_coal
      - repair_charcoal_factory
   aesthetics:
@@ -1209,13 +1214,73 @@ recipes:
       red_netherbrick:
         material: RED_NETHER_BRICKS
         amount: 32
-  charcoal_from_logs:
+  charcoal_from_oak_log:
     production_time: 4s
     name: Make Charcoal from Oak Logs
     type: PRODUCTION
     input:
       log:
         material: OAK_LOG
+        amount: 64
+    output:
+      charcoal:
+        material: CHARCOAL
+        amount: 128
+  charcoal_from_spruce_log:
+    production_time: 4s
+    name: Make Charcoal from Spruce Logs
+    type: PRODUCTION
+    input:
+      log:
+        material: SPRUCE_LOG
+        amount: 64
+    output:
+      charcoal:
+        material: CHARCOAL
+        amount: 128
+  charcoal_from_birch_log:
+    production_time: 4s
+    name: Make Charcoal from Birch Logs
+    type: PRODUCTION
+    input:
+      log:
+        material: BIRCH_LOG
+        amount: 64
+    output:
+      charcoal:
+        material: CHARCOAL
+        amount: 128
+  charcoal_from_jungle_log:
+    production_time: 4s
+    name: Make Charcoal from Jungle Logs
+    type: PRODUCTION
+    input:
+      log:
+        material: JUNGLE_LOG
+        amount: 64
+    output:
+      charcoal:
+        material: CHARCOAL
+        amount: 128
+  charcoal_from_acacia_log:
+    production_time: 4s
+    name: Make Charcoal from Acacia Logs
+    type: PRODUCTION
+    input:
+      log:
+        material: ACACIA_LOG
+        amount: 64
+    output:
+      charcoal:
+        material: CHARCOAL
+        amount: 128
+  charcoal_from_dark_oak_log:
+    production_time: 4s
+    name: Make Charcoal from Dark Oak Logs
+    type: PRODUCTION
+    input:
+      log:
+        material: DARK_OAK_LOG
         amount: 64
     output:
       charcoal:


### PR DESCRIPTION
Due to the change from damage values to independent blocks when defining block varients, the current state of the charcoal factory was limiting inputs to oak logs exclusively, rather than the expected behavior of using whatever log they were inputting to create charcoal.

I just made a new recipe for each log type to convert to charcoal. Unless there exists a way for factorymod to lump all logs together still, this is the best solution to the issue I could come up with.

An advantage of doing things this way though, is if people wanted to, you all could tweak individual log to charcoal values depending on say, how difficult it was to automate and/or chop down each type of tree. But that's by no means necessary.