### PR TITLE
Spawn Item Changes

### DIFF
--- a/templates/public/plugins/SimpleAdminHacks/config.yml.j2
+++ b/templates/public/plugins/SimpleAdminHacks/config.yml.j2
@@ -74,7 +74,7 @@ hacks:
             - "Gift from the Admins as you"
             - "begin your journey on CivClassic"
        - ==: org.bukkit.inventory.ItemStack
-         type: BED
+         type: WHITE_BED
          amount: 1  
          meta:
            ==: ItemMeta
@@ -83,6 +83,14 @@ hacks:
             - "This world is unforgiving."
             - "Be sure to get a good night's"
             - "rest soon."
+       - ==: org.bukkit.inventory.ItemStack
+         type: OAK_BOAT
+         amount: 1  
+         meta:
+           ==: ItemMeta
+           meta-type: UNSPECIFIC
+           lore:
+            - "The world is your oyster"
   Introbook:
     enabled: true  
     follow: true


### PR DESCRIPTION
- Added an `OAK_BOAT` to the a new player's spawn inventory
- Gave `OAK_BOAT` unique lore to match the the other spawn items
- Corrected `BED` to `WHITE_BED` to be consistent with 1.14's item naming, as and I chose white specifically to allow new players to dye their beds to whatever color they'd like.
- Confirmed that `COOKIE` is the correct item type.