### PR TITLE
Attempt to fix mob egg issue

### DIFF
--- a/templates/public/plugins/ClearLag/config.yml.j2
+++ b/templates/public/plugins/ClearLag/config.yml.j2
@@ -141,7 +141,7 @@ firespread-reducer:
 #     and possibly removed.
 chunk-entity-limiter:
   enabled: true
-  limit: 5
+  limit: 30
   entities:
     - bat
     - blaze


### PR DESCRIPTION
Setting this to a higher number should help with mob egg spawns as it did locally. However if people still cant spawn mob eggs from this high a setting, might be best to disable but keep monitoring.
#13 