### PR TITLE
Added recipe for cooking cactus into green dye in Grill

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -181,6 +181,7 @@ factories:
      - cook_rabbit
      - cook_fish
      - cook_salmon
+     - cook_cactus
      - repair_grill
   bakery:
     type: FCC
@@ -799,6 +800,18 @@ recipes:
     output:
       cooked_salmon:
         material: COOKED_SALMON
+        amount: 48
+  cook_cactus:
+    production_time: 4s
+    name: Cook Cactus
+    type: PRODUCTION
+    input:
+      cactus:
+        material: CACTUS
+        amount: 32
+    output:
+      green dye:
+        material: GREEN_DYE
         amount: 48
   bake_bread:
     production_time: 4s


### PR DESCRIPTION
This adds a recipe to cook 32 cactus into 48 green dye using a Grill.

The conversion rate is the same as other grill recipes. It's mostly a QoL over using tons of furnace to get a bunch of green dye.

The grill was chosen because it makes more sense to use a damn grill over the same thing that you'd use for smelting sand into glass. 