### PR TITLE
Orebfuscator update

### DIFF
--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -1,0 +1,116 @@
+ConfigVersion: 13
+Booleans:
+  UseCache: true
+  Enabled: true
+  UpdateOnDamage: true
+  NoObfuscationForMetadata: true
+  NoObfuscationForOps: false
+  NoObfuscationForPermission: false
+  LoginNotification: true
+Integers:
+  MaxLoadedCacheFiles: 64
+  DeleteCacheFilesAfterDays: 0
+  EngineMode: 2
+  InitialRadius: 1
+  UpdateRadius: 2
+Strings:
+  CacheLocation: orebfuscator_cache
+  NoObfuscationForMetadataTagName: NPC
+Lists:
+  TransparentBlocks: []
+  NonTransparentBlocks: []
+Worlds:
+  Default:
+    Types:
+    - DEFAULT
+    Enabled: false
+    AntiTexturePackAndFreecam: true
+    AirGeneratorMaxChance: 43
+    DarknessHideBlocks: false
+    BypassObfuscationForSignsWithText: false
+    DarknessBlocks:
+    - MOB_SPAWNER
+    - CHEST
+    Mode1Block: STONE
+    RandomBlocks: []
+    ObfuscateBlocks: []
+    ProximityHider:
+      Enabled: true
+      Distance: 8
+      SpecialBlock: STONE
+      Y: 255
+      UseSpecialBlock: true
+      ObfuscateAboveY: false
+      ProximityHiderBlocks:
+      - DISPENSER
+      - MOB_SPAWNER
+      - CHEST
+      - DIAMOND_ORE
+      - WORKBENCH
+      - FURNACE
+      - BURNING_FURNACE
+      - ENCHANTMENT_TABLE
+      - EMERALD_ORE
+      - ENDER_CHEST
+      - ANVIL
+      - TRAPPED_CHEST
+      UseFastGazeCheck: true
+  Normal:
+    Types:
+    - NORMAL
+    Mode1Block: STONE
+    RandomBlocks:
+    - STONE
+    - COBBLESTONE
+    - WOOD
+    - GOLD_ORE
+    - IRON_ORE
+    - COAL_ORE
+    - LAPIS_ORE
+    - TNT
+    - MOSSY_COBBLESTONE
+    - OBSIDIAN
+    - DIAMOND_ORE
+    - REDSTONE_ORE
+    - CLAY
+    - EMERALD_ORE
+    ObfuscateBlocks:
+    - GOLD_ORE
+    - IRON_ORE
+    - COAL_ORE
+    - LAPIS_ORE
+    - CHEST
+    - DIAMOND_ORE
+    - REDSTONE_ORE
+    - GLOWING_REDSTONE_ORE
+    - EMERALD_ORE
+    - ENDER_CHEST
+  TheEnd:
+    Types:
+    - THE_END
+    Mode1Block: ENDER_STONE
+    RandomBlocks:
+    - BEDROCK
+    - OBSIDIAN
+    - ENDER_STONE
+    - PURPUR_BLOCK
+    - END_BRICKS
+    ObfuscateBlocks:
+    - ENDER_STONE
+  Nether:
+    Types:
+    - NETHER
+    Mode1Block: NETHERRACK
+    RandomBlocks:
+    - GRAVEL
+    - NETHERRACK
+    - SOUL_SAND
+    - NETHER_BRICK
+    - QUARTZ_ORE
+    ObfuscateBlocks:
+    - NETHERRACK
+    - QUARTZ_ORE
+  EnabledWorlds:
+    Names:
+    - world
+    Enabled: true

--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -97,19 +97,6 @@ Worlds:
     - END_BRICKS
     ObfuscateBlocks:
     - ENDER_STONE
-  Nether:
-    Types:
-    - NETHER
-    Mode1Block: NETHERRACK
-    RandomBlocks:
-    - GRAVEL
-    - NETHERRACK
-    - SOUL_SAND
-    - NETHER_BRICK
-    - QUARTZ_ORE
-    ObfuscateBlocks:
-    - NETHERRACK
-    - QUARTZ_ORE
   EnabledWorlds:
     Names:
     - world

--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -54,6 +54,16 @@ Worlds:
       - ENDER_CHEST
       - ANVIL
       - TRAPPED_CHEST
+      - BLAST_FURNACE
+      - SMOKER
+      - STONECUTTER
+      - LOOM
+      - COMPOSTER
+      - CARTOGRAPHY_TABLE
+      - BARREL
+      - JUKEBOX # Log Snitch
+      - NOTE_BLOCK # Snitch
+      - SPONGE # Vault Bastion
       UseFastGazeCheck: true
   Normal:
     Types:
@@ -62,28 +72,29 @@ Worlds:
     RandomBlocks:
     - STONE
     - COBBLESTONE
-    - WOOD
-    - GOLD_ORE
-    - IRON_ORE
-    - COAL_ORE
-    - LAPIS_ORE
-    - TNT
     - MOSSY_COBBLESTONE
+    - ACACIA_PLANKS
+    - BIRCH_PLANKS
+    - DARK_OAK_PLANKS
+    - JUNGLE_PLANKS
+    - OAK_PLANKS
+    - SPRUCE_PLANKS
     - OBSIDIAN
-    - DIAMOND_ORE
-    - REDSTONE_ORE
+    - PACKED_ICE
     - CLAY
-    - EMERALD_ORE
     ObfuscateBlocks:
-    - GOLD_ORE
-    - IRON_ORE
+    - MOSSY_COBBLESTONE
     - COAL_ORE
     - LAPIS_ORE
-    - CHEST
-    - DIAMOND_ORE
     - REDSTONE_ORE
     - GLOWING_REDSTONE_ORE
+    - IRON_ORE
+    - GOLD_ORE
+    - DIAMOND_ORE
     - EMERALD_ORE
+    - CLAY
+    - CHEST
+    - TRAPPED_CHEST
     - ENDER_CHEST
   TheEnd:
     Types:


### PR DESCRIPTION
The overall changes will just show all green. Look at the individual commits to see what's happening.

I've added back the missing entries from the [old config](https://github.com/CivClassic/Configs/blob/master/Orebfuscator4/config.yml#L57-L59), as well as added the new blocks from 1.13 and 1.14. I've left out the blocks that are exclusively villager task based (such as Smithing Tables) and blocks that have aesthetic purposes (like Campfires and Lecterns). Other blocks that are disabled in Civclassic (like Scaffolding and Grindstones) have been left out.

Some of the changes to `RandomBlocks` and `ObfuscateBlocks` are just re-organisation to put the ores together and such so it's more readable for future contributors. I've removed ore completely as the.. confetti blocks.. for a lack of a better term, since people seem to fine them frustrating when mining. TNT has been removed due to obvious issues with world downloads.