### PR TITLE
Replace crack_fossil bucket output with heart of the sea

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -5566,10 +5566,10 @@ recipes:
         iron_horse_armor:
           material: IRON_HORSE_ARMOR
           amount: 1
-      bucket:
+      heart_of_the_sea:
         chance: 0.00029411764
-        bucket:
-          material: BUCKET
+        heart_of_the_sea:
+          material: HEART_OF_THE_SEA
           amount: 1
       prismarine_shards:
         chance: 0.00029411764


### PR DESCRIPTION
Made in response to https://github.com/CivClassic/AnsibleSetup/issues/29 
Unsure whether fossil 'chance' values need to be specific so I've replaced the bucket output