### PR TITLE
Enable block limits

### DIFF
--- a/templates/public/plugins/SimpleAdminHacks/config.yml.j2
+++ b/templates/public/plugins/SimpleAdminHacks/config.yml.j2
@@ -28,7 +28,7 @@ hacks:
     badOmen: false
     pigPortalSpawnMultiplier: 1000001
     chunkLimits:
-      enabled: false
+      enabled: true
       exceededMessage: '&9Limit reached for this chunk, you cannot place more of this type of block.'
       tileEntities:
         HOPPER: 16
@@ -38,7 +38,6 @@ hacks:
         DROPPER: 16
         REDSTONE_COMPARATOR: 12
         FURNACE: 40
-        SLIME_BLOCK: 8
         PISTON_EXTENSION: 8
         PISTON_MOVING_PIECE: 8
       exempt:


### PR DESCRIPTION
- Currently CivClassic seems to have nothing enforcing block limits (eg. try placing 64 dropper's in a single chunk). 
- Remove SLIME_BLOCK as SAH only limits tile entities. 