### PR TITLE
Fixed wrong obfuscation material name

### DIFF
--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -99,7 +99,7 @@ Worlds:
   TheEnd:
     Types:
     - THE_END
-    Mode1Block: ENDER_STONE
+    Mode1Block: END_STONE
     RandomBlocks:
     - BEDROCK
     - OBSIDIAN
@@ -107,7 +107,7 @@ Worlds:
     - PURPUR_BLOCK
     - END_BRICKS
     ObfuscateBlocks:
-    - ENDER_STONE
+    - END_STONE
   EnabledWorlds:
     Names:
     - world


### PR DESCRIPTION
End stone was registered as ENDER_STONE rather than END_STONE which prevented plugin from functioning properly.