### PR TITLE
Balance ore chances

### DIFF
--- a/templates/public/plugins/HiddenOre/config.yml.j2
+++ b/templates/public/plugins/HiddenOre/config.yml.j2
@@ -55,7 +55,7 @@ drops:
             - Crack me in a factory for a prize!
       minY: 1
       maxY: 256
-      chance: 0.005
+      chance: 0.0075
       minAmount: 1
       maxAmount: 1
    quartz_transform:
@@ -77,8 +77,8 @@ drops:
       minY: 1
       maxY: 256
       chance: 0.012
-      minAmount: 3
-      maxAmount: 12
+      minAmount: 2
+      maxAmount: 6
       transformIfAble: true
    iron_ore_transform:
       package:
@@ -88,8 +88,8 @@ drops:
       minY: 1
       maxY: 256
       chance: 0.015
-      minAmount: 2
-      maxAmount: 8
+      minAmount: 1
+      maxAmount: 4
       transformIfAble: true
       biomes:
          MESA:
@@ -105,9 +105,9 @@ drops:
          amount: 1
       minY: 1
       maxY: 70
-      chance: 0.0013
-      minAmount: 2
-      maxAmount: 8
+      chance: 0.0035
+      minAmount: 1
+      maxAmount: 4
       transformIfAble: true
    redstone_ore_transform:
       package:
@@ -116,7 +116,7 @@ drops:
          amount: 1
       minY: 1
       maxY: 70
-      chance: 0.0013
+      chance: 0.0040
       minAmount: 1
       maxAmount: 3
       transformIfAble: true
@@ -127,9 +127,9 @@ drops:
          amount: 1
       minY: 1
       maxY: 70
-      chance: 0.003
-      minAmount: 2
-      maxAmount: 8
+      chance: 0.0045
+      minAmount: 1
+      maxAmount: 4
       transformIfAble: true
    emerald_ore_dank:
       package:


### PR DESCRIPTION
Halve coal/iron cluster size. Gold, Lapis more common but smaller clusters. Redstone more common same size cluster. Fossils slightly more common. 