### PR TITLE
Scouter9001 - Grow mushrooms in bio lab factory.

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -379,6 +379,8 @@ factories:
      - acacia_to_sapling
      - sapling_to_dark_oak
      - dark_oak_to_sapling
+     - grow_mushroom_brown
+     - grow_mushroom_red
      - make_mushroom_brown
      - make_mushroom_red
      - make_mushroom_stem
@@ -4834,6 +4836,50 @@ recipes:
         amount: 128
         lore:
           - Crate
+  grow_mushroom_brown:
+    type: PRODUCTION
+    name: Make Brown Mushrooms
+    production_time: 60s
+    fuel_consumption_intervall: 2s
+    input:
+      podzol:
+        material: PODZOL
+        amount: 64
+      spider_eye:
+        material: SPIDER_EYE
+        amount: 128
+      red_dye:
+        material: BROWN_DYE
+        amount: 64
+      white_dye:
+        material: WHITE_DYE
+        amount: 64
+    output:
+      brown_mushroom:
+        material: BROWN_MUSHROOM
+        amount: 64
+  grow_mushroom_red:
+    type: PRODUCTION
+    name: Make Red Mushrooms
+    production_time: 60s
+    fuel_consumption_intervall: 2s
+    input:
+      podzol:
+        material: PODZOL
+        amount: 64
+      spider_eye:
+        material: SPIDER_EYE
+        amount: 128
+      red_dye:
+        material: RED_DYE
+        amount: 64
+      white_dye:
+        material: WHITE_DYE
+        amount: 64
+    output:
+      red_mushroom:
+        material: RED_MUSHROOM
+        amount: 64
   make_mushroom_brown:
     type: PRODUCTION
     name: Make Brown Mushroom Blocks

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -4839,7 +4839,7 @@ recipes:
   grow_mushroom_brown:
     type: PRODUCTION
     name: Make Brown Mushrooms
-    production_time: 60s
+    production_time: 10s
     fuel_consumption_intervall: 2s
     input:
       podzol:
@@ -4861,7 +4861,7 @@ recipes:
   grow_mushroom_red:
     type: PRODUCTION
     name: Make Red Mushrooms
-    production_time: 60s
+    production_time: 10s
     fuel_consumption_intervall: 2s
     input:
       podzol:

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -4848,6 +4848,9 @@ recipes:
       spider_eye:
         material: SPIDER_EYE
         amount: 128
+      phantom_membrane:
+        material: PHANTOM_MEMBRANE
+        amount: 16
       red_dye:
         material: BROWN_DYE
         amount: 64
@@ -4870,6 +4873,9 @@ recipes:
       spider_eye:
         material: SPIDER_EYE
         amount: 128
+      phantom_membrane:
+        material: PHANTOM_MEMBRANE
+        amount: 16
       red_dye:
         material: RED_DYE
         amount: 64


### PR DESCRIPTION
Enable players to create brown and red mushrooms in the bio lab.

1.  Automatic mushroom farms can cause server lag
2.  AFK'ing a mushroom farm is tedious, encourages ALTs, and keeps chunks loaded
3.  The bio lab already has recipes to make mushroom blocks from mushrooms.  This enables a natural progression from creating mushrooms, to creating mushroom blocks from mushrooms.
4.  Due to non-linear spread mechanics, persisting mushroom growth could cause additional resource utilization from the server to track things like cross-chunk spreading and loading.

I've created an initial recipe that is open for discussion.  I liked the idea of combining "gross things" to simulate the soil environment that a mushroom would naturally appear in.

