### PR TITLE
Added several 1.16 recipes

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -3961,7 +3961,7 @@ recipes:
         material: GRASS
         amount: 8
       lapis:
-        material: LAPIS_LAZULI
+        material: BLUE_DYE
         amount: 8
     output:
       tube_coral:
@@ -3977,7 +3977,7 @@ recipes:
         material: GRASS
         amount: 8
       lapis:
-        material: LAPIS_LAZULI
+        material: BLUE_DYE
         amount: 8
     output:
       tube_coral_fan:
@@ -3993,7 +3993,7 @@ recipes:
         material: GRASS_BLOCK
         amount: 8
       lapis:
-        material: LAPIS_LAZULI
+        material: BLUE_DYE
         amount: 8
     output:
       tube_coral_block:

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -85,6 +85,9 @@ factories:
      - make_smooth_stone_slab
      - make_smooth_sandstone_slab
      - make_smooth_quartz_slab
+     - make_soul_soil
+     - make_basalt
+     - make_blackstone
      - repair_aesthetics
   dye_wool:
     type: FCC
@@ -5018,6 +5021,58 @@ recipes:
         amount: 64
         lore:
           - Smooth double slab
+  make_soul_soil:
+    forceInclude: true
+    type: PRODUCTION
+    name: Make Soul Soil
+    production_time: 4s
+    input:
+      soulsand:
+        material: SOUL_SAND
+        amount: 32
+      dirt:
+        material: DIRT
+        amount: 32
+    output:
+      soulsoil:
+        material: SOUL_SOIL
+        amount: 64
+  make_basalt:
+    forceInclude: true
+    type: PRODUCTION
+    name: Make Basalt
+    production_time: 4s
+    input:
+      cobblestone:
+        material: NETHERRACK
+        amount: 64
+      blue_ice:
+        material: BLUE_ICE
+        amount: 4
+      soul_soil:
+        material: SOUL_SOIL
+        amount: 4
+    output:
+      basalt:
+        material: BASALT
+        amount: 96
+  make_blackstone:
+    forceInclude: true
+    type: PRODUCTION
+    name: Make Blackstone
+    production_time: 4s
+    input:
+      cobblestone:
+        material: COBBLESTONE
+        amount: 32
+      netherrack:
+        material: NETHERRACK
+        amount: 32
+    output:
+      blackstone:
+        material: BLACKSTONE
+        amount: 64
+    
   upgrade_to_printer:
     forceInclude: true
     production_time: 4s

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -979,7 +979,7 @@ recipes:
         amount: 64
     output:
       netherbrick:
-        material: NETHER_BRICK
+        material: NETHER_BRICKS
         amount: 64
   smelt_red_netherbrick:
     forceInclude: true


### PR DESCRIPTION
As the title suggests, this adds several recipes for new 1.16 blocks.
It also changes the Lapis Lazuli requirement for Blue Coral to Blue Dye so that it can be produced from blue flowers.

Here's the propositions for 1.16 nether blocks. These can be produced in the aesthetic factory.
- 32 dirt + 32 soul sand => 64 soul soil

- 32 cobble + 32 netherrack => 64 blackstone. 
Blackstone is the nether equivalent of cobblestone. Obtaining by mixing netherrack and cobblestone seems natural.

- 64 netherrack + 4 blue ice + 4 soul soil => 96 basalt
This one might seems weirder and more controversial than the rest. That's because basalt can be obtained with a [generator](https://minecraft.gamepedia.com/Basalt#Post-generation) using lava, soul soil and blue ice.
Contrary to the generator, this recipe consumes the blue ice and the soul soil and I think that doesn't render the former useless. Lazier players could always use the more expensive method whereas more industrious one/botters could use the generator.

Obviously, these are just propositions and they are open to debate.