### PR TITLE
Updated Orebfuscator config

### DIFF
--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -25,6 +25,7 @@ world:
       - chest
       - ender_chest
       - trapped_chest
+      - barrel
       - emerald_ore
       - diamond_ore
       - gold_ore
@@ -52,7 +53,6 @@ world:
       - red_shulker_box
       - black_shulker_box
     randomBlocks:
-      cave_air : 45
       clay: 1
       coal_ore: 1
       cobblestone: 1
@@ -65,7 +65,6 @@ world:
       obsidian: 1
       redstone_ore: 1
       stone: 1
-      tnt: 1
   - worlds:
       - world_nether
     enabled: true
@@ -78,6 +77,7 @@ world:
       - chest
       - ender_chest
       - trapped_chest
+      - barrel
       - netherrack
       - nether_quartz_ore
       - shulker_box
@@ -119,6 +119,7 @@ world:
       - chest
       - ender_chest
       - trapped_chest
+      - barrel
       - shulker_box
       - white_shulker_box
       - orange_shulker_box
@@ -155,6 +156,7 @@ proximity:
       chest: {}
       ender_chest: {}
       trapped_chest: {}
+      barrel: {}
       anvil: {}
       crafting_table: {}
       dispenser: {}
@@ -202,6 +204,7 @@ proximity:
       chest: {}
       ender_chest: {}
       trapped_chest: {}
+      barrel: {}
       anvil: {}
       crafting_table: {}
       dispenser: {}
@@ -255,6 +258,7 @@ proximity:
       chest: {}
       ender_chest: {}
       trapped_chest: {}
+      barrel: {}
       anvil: {}
       crafting_table: {}
       dispenser: {}


### PR DESCRIPTION
See #68 

- Removed tnt and air pockets
- Added barrels to the list of obfuscable blocks

Note: Unlike #62 , Orebfuscator5 loads the config from `Orebfsuscator/` and not `Orebfuscator5/`. 