### PR TITLE
Added recipe for crying obsidian

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -4913,14 +4913,17 @@ recipes:
     input:
       obsidian:
         material: OBSIDIAN
-        amount: 64
+        amount: 128
       tears:
         material: GHAST_TEAR
-        amount: 2
+        amount: 1
+      glowstone:
+        material: GLOWSTONE_DUST
+        amount: 1
     output:
       crying_obsidian:
         material: CRYING_OBSIDIAN
-        amount: 64
+        amount: 128
 
   bind_books:
     type: PRODUCTION

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -88,6 +88,7 @@ factories:
      - make_soul_soil
      - make_basalt
      - make_blackstone
+     - make_crying_obsidian
      - repair_aesthetics
   dye_wool:
     type: FCC
@@ -4904,6 +4905,23 @@ recipes:
       blackstone:
         material: BLACKSTONE
         amount: 64
+  make_crying_obsidian:
+    forceInclude: true
+    type: PRODUCTION
+    name: Make Crying Obsidian
+    production_time: 4s
+    input:
+      obsidian:
+        material: OBSIDIAN
+        amount: 64
+      tears:
+        material: GHAST_TEAR
+        amount: 2
+    output:
+      crying_obsidian:
+        material: CRYING_OBSIDIAN
+        amount: 64
+
   bind_books:
     type: PRODUCTION
     name: Bind Books


### PR DESCRIPTION
This is a proposition for:

2 ghast tears + 64 obsidian => 64 crying obsidian

Crying obsidian has the same hardness as regular obsidian. The main difference is that it emits light (10).
I think the 2 ghast tears justify this small improvement, while also giving more use to the tears. 

EDIT: It is worth noting that crying obsidian can be used to make respawn anchors. They don't work in the overworld/end and their explosions are [disabled by default](https://github.com/CivClassic/SimpleAdminHacks/pull/23).