### PR TITLE
gray local chat for 800m+ distance (outer 200m ring)

### DIFF
--- a/templates/public/plugins/CivChat2/config.yml.j2
+++ b/templates/public/plugins/CivChat2/config.yml.j2
@@ -19,7 +19,7 @@ chat:
       color: WHITE
     far:
       range: 800
-      color: DARK_GRAY
+      color: GRAY
 info:
   #debug: lots of debugging logging will show up in the console def=false
   debug: false

--- a/templates/public/plugins/CivChat2/config.yml.j2
+++ b/templates/public/plugins/CivChat2/config.yml.j2
@@ -13,6 +13,13 @@ chat:
   yIncreaseScale: 1
   killRange: 1000
   dynamicColoring: true
+  colors:
+    near:
+      range: 0
+      color: WHITE
+    far:
+      range: 800
+      color: DARK_GRAY
 info:
   #debug: lots of debugging logging will show up in the console def=false
   debug: false

--- a/templates/public/plugins/CivChat2/config.yml.j2
+++ b/templates/public/plugins/CivChat2/config.yml.j2
@@ -12,7 +12,7 @@ chat:
   #Coded formula globalChatRange = globalChatRange + (globalChatRange * ((yIncreaseScale/1000) * #blocksaboveydist)))
   yIncreaseScale: 1
   killRange: 1000
-  dynamicColoring: true
+  dynamicColoring: false
   colors:
     near:
       range: 0


### PR DESCRIPTION
this makes triangulation (using local chat colors) less effective