### PR TITLE
Reduce damage_effect particles

### DIFF
--- a/templates/public/plugins/Citadel/config.yml.j2
+++ b/templates/public/plugins/Citadel/config.yml.j2
@@ -58,8 +58,8 @@ reinforcements:
       offset: 0.1
     damage_effect:
       type: END_ROD
-      speed: 0.07
-      particleCount: 60
+      speed: 0.045
+      particleCount: 15
       offset: 0.0
     destruction_effect:
       type: END_ROD


### PR DESCRIPTION
How damaging iron reinforced blocks currently looks for reference. Perhaps a further improvement would be to not use end_rod particles at all as they take so long to dissipate.

![iron](https://user-images.githubusercontent.com/40185801/90962455-a6f18300-e49f-11ea-8025-58957b8e2598.png)
