### PR TITLE
Basic recipe for Crimson and Warped Stems

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -383,6 +383,8 @@ factories:
      - acacia_to_sapling
      - sapling_to_dark_oak
      - dark_oak_to_sapling
+     - make_crimson_stem
+     - make_warped_stem
      - grow_mushroom_brown
      - grow_mushroom_red
      - make_mushroom_brown
@@ -1698,6 +1700,38 @@ recipes:
       oak_sapling:
         material: OAK_SAPLING
         amount: 32
+  make_crimson_stem:
+    forceInclude: true
+    production_time: 4s
+    name: Make Crimson Stem
+    type: PRODUCTION
+    input:
+      sugar_cane:
+        material: OAK_LOG
+        amount: 8
+      sugar_cane:
+        material: GLOWSTONE_DUST
+        amount: 1
+    output:
+      bamboo:
+        material: CRIMSON_STEM
+        amount: 8
+  make_warped_stem:
+    forceInclude: true
+    production_time: 4s
+    name: Make Warped Stem
+    type: PRODUCTION
+    input:
+      sugar_cane:
+        material: OAK_LOG
+        amount: 8
+      sugar_cane:
+        material: PRISMARINE_SHARD
+        amount: 1
+    output:
+      bamboo:
+        material: WARPED_STEM
+        amount: 8
   dye_clay_white:
     production_time: 4s
     name: Dye Clay White


### PR DESCRIPTION
Added a recipe for WARPED_STEM and CRIMSON_STEM to the biolab. Once the fungi forms of them are confirmed to be working, we could swap out the logs/stems for 1 sapling/1 fungi respectively, if you wanted.