### PR TITLE
Make Bakeries require brick blocks.

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -194,8 +194,8 @@ factories:
     citadelBreakReduction: 1.0
     setupcost:
       brick:
-        material: BRICK
-        amount: 64
+        material: BRICKS
+        amount: 16
       oak log:
         material: OAK_LOG
         amount: 12


### PR DESCRIPTION
Brick blocks are easier to create via the basic smelter and would be more appropiate than individual bricks, which have to be smelted in a furnace manually.