### PR TITLE
Add JSON Printing Plate recipe

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -648,6 +648,7 @@ factories:
       - bind_books
       - bind_writable_books
       - craft_printing_plate
+      - craft_printing_plate_json
       - print_book
       - print_note
       - print_secure_note
@@ -5016,6 +5017,18 @@ recipes:
   craft_printing_plate:
     type: PRINTINGPLATE
     name: Craft Printing Plate
+    production_time: 4s
+    input:
+      iron:
+        material: IRON_INGOT
+        amount: 1
+    output:
+      plate:
+        material: OAK_TRAPDOOR
+        amount: 1
+  craft_json_printing_plate:
+    type: PRINTINGPLATEJSON
+    name: Craft JSON Printing Plate
     production_time: 4s
     input:
       iron:


### PR DESCRIPTION
By making a book filled with JSON Raw Text and the running the recipe, it'll take the raw text, sanitize it, and then output a printing plate that can be used as normal to print very fancy books.

To have multiple pages, you simply insert the string `<<PAGE>>` to split off a new page.

(text copied from https://github.com/CivClassic/FactoryMod/pull/39 for future reference)