### PR TITLE
add sticks -> chest carpentry recipe

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -430,6 +430,7 @@ factories:
      - make_beehive
      - make_casing
      - make_crates
+     - sticks_to_chest
      - repair_carpentry
   rails:
     type: FCC
@@ -2947,6 +2948,18 @@ recipes:
       beehive:
         material: BEEHIVE
         amount: 1
+  sticks_to_chest:
+    production_time: 4s
+    name: Reconstitute Sticks to Chests
+    type: PRODUCTION
+    input:
+      stick:
+        material: STICK
+        amount: 64
+    output:
+      chest:
+        material: CHEST
+        amount: 4
   repair_carpentry:
     production_time: 4s
     name: Repair Factory


### PR DESCRIPTION
leaves now drop sticks which are not consumed in any great quantities unlike logs+leaves, meaning tree farming now produces many relatively useless sticks as a byproduct

allowing sticks -> chests effectively provides a minor buff to tree farm wood output

this recipe is 1:1 with crafting chests from planks which could be changed if necessary