### PR TITLE
add flint -> sand grinding mill recipe

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -720,6 +720,7 @@ factories:
      - crush_stone
      - crush_cobble
      - crush_gravel
+     - grind_flint
      - grind_sandstone
      - grind_red_sandstone
      - crush_coarse
@@ -5058,6 +5059,18 @@ recipes:
     input:
       gravel:
         material: GRAVEL
+        amount: 32
+    output:
+      sand:
+        material: SAND
+        amount: 32
+  grind_flint:
+    production_time: 4s
+    name: Grind Flint
+    type: PRODUCTION
+    input:
+      flint:
+        material: FLINT
         amount: 32
     output:
       sand:


### PR DESCRIPTION
flint is an often unintentionally collected byproduct of gravel, with little use

dunno if getting sand from flint makes any sense irl but it matches the gravel -> sand grinding recipe, including the 1:1 ratio which could be adjusted