### PR TITLE
cleaned up and adjusted in line with old config

### DIFF
--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -65,91 +65,15 @@ world:
       obsidian: 1
       redstone_ore: 1
       stone: 1
-  - worlds:
-      - world_nether
-    enabled: true
-    darknessBlocks:
-      - chest
-      - ender_chest
-      - trapped_chest
-      - spawner
-    hiddenBlocks:
-      - chest
-      - ender_chest
-      - trapped_chest
-      - barrel
-      - netherrack
-      - nether_quartz_ore
-      - shulker_box
-      - white_shulker_box
-      - orange_shulker_box
-      - magenta_shulker_box
-      - light_blue_shulker_box
-      - yellow_shulker_box
-      - lime_shulker_box
-      - pink_shulker_box
-      - gray_shulker_box
-      - light_gray_shulker_box
-      - cyan_shulker_box
-      - purple_shulker_box
-      - blue_shulker_box
-      - brown_shulker_box
-      - green_shulker_box
-      - red_shulker_box
-      - black_shulker_box
-      - ancient_debris
-      - nether_gold_ore
-      - basalt
-      - soul_sand
-      - soul_soil
-    randomBlocks:
-      netherrack: 4
-      nether_quartz_ore: 1
-      nether_gold_ore: 1
-      ancient_debris: 1
-  - worlds:
-      - world_the_end
-    enabled: true
-    darknessBlocks:
-      - chest
-      - ender_chest
-      - trapped_chest
-      - spawner
-    hiddenBlocks:
-      - chest
-      - ender_chest
-      - trapped_chest
-      - barrel
-      - shulker_box
-      - white_shulker_box
-      - orange_shulker_box
-      - magenta_shulker_box
-      - light_blue_shulker_box
-      - yellow_shulker_box
-      - lime_shulker_box
-      - pink_shulker_box
-      - gray_shulker_box
-      - light_gray_shulker_box
-      - cyan_shulker_box
-      - purple_shulker_box
-      - blue_shulker_box
-      - brown_shulker_box
-      - green_shulker_box
-      - red_shulker_box
-      - black_shulker_box
-    randomBlocks:
-      end_stone: 1
-      end_stone_bricks: 1
-      bedrock: 1
-      obsidian: 1
-      purpur_block: 1
-
+      air: 15
+      
 proximity:
   - worlds:
       - world
+      - world_the_end
     enabled: true
-    distance: 16
-    useFastGazeCheck: false
+    distance: 8
+    useFastGazeCheck: true
     hiddenBlocks:
       diamond_ore: {}
       emerald_ore: {}
@@ -193,107 +117,9 @@ proximity:
       black_shulker_box: {}
       bee_nest: {}
       beehive: {}
+      bone_block: {}
+      sponge: {}
+      note_block: {}
+      jukebox: {}
     randomBlocks:
-      stone: 1
-  - worlds:
-      - world_nether
-    enabled: true
-    distance: 16
-    useFastGazeCheck: false
-    hiddenBlocks:
-      chest: {}
-      ender_chest: {}
-      trapped_chest: {}
-      barrel: {}
-      anvil: {}
-      crafting_table: {}
-      dispenser: {}
-      enchanting_table: {}
-      furnace: {}
-      blast_furnace: {}
-      cartography_table: {}
-      fletching_table: {}
-      grindstone: {}
-      composter: {}
-      lectern: {}
-      loom: {}
-      smithing_table: {}
-      smoker: {}
-      stonecutter: {}
-      hopper: {}
-      spawner: {}
-      shulker_box: {}
-      white_shulker_box: {}
-      orange_shulker_box: {}
-      magenta_shulker_box: {}
-      light_blue_shulker_box: {}
-      yellow_shulker_box: {}
-      lime_shulker_box: {}
-      pink_shulker_box: {}
-      gray_shulker_box: {}
-      light_gray_shulker_box: {}
-      cyan_shulker_box: {}
-      purple_shulker_box: {}
-      blue_shulker_box: {}
-      brown_shulker_box: {}
-      green_shulker_box: {}
-      red_shulker_box: {}
-      black_shulker_box: {}
-      bee_nest: {}
-      beehive: {}
-      ancient_debris: {}
-      nether_gold_ore: {}
-      respawn_anchor: {}
-    randomBlocks:
-      netherrack: 4
-      nether_quartz_ore: 1
-      nether_gold_ore: 1
-      ancient_debris: 1
-  - worlds:
-      - world_the_end
-    enabled: true
-    distance: 16
-    useFastGazeCheck: false
-    hiddenBlocks:
-      chest: {}
-      ender_chest: {}
-      trapped_chest: {}
-      barrel: {}
-      anvil: {}
-      crafting_table: {}
-      dispenser: {}
-      enchanting_table: {}
-      furnace: {}
-      blast_furnace: {}
-      cartography_table: {}
-      fletching_table: {}
-      grindstone: {}
-      composter: {}
-      lectern: {}
-      loom: {}
-      smithing_table: {}
-      smoker: {}
-      stonecutter: {}
-      hopper: {}
-      spawner: {}
-      shulker_box: {}
-      white_shulker_box: {}
-      orange_shulker_box: {}
-      magenta_shulker_box: {}
-      light_blue_shulker_box: {}
-      yellow_shulker_box: {}
-      lime_shulker_box: {}
-      pink_shulker_box: {}
-      gray_shulker_box: {}
-      light_gray_shulker_box: {}
-      cyan_shulker_box: {}
-      purple_shulker_box: {}
-      blue_shulker_box: {}
-      brown_shulker_box: {}
-      green_shulker_box: {}
-      red_shulker_box: {}
-      black_shulker_box: {}
-      bee_nest: {}
-      beehive: {}
-    randomBlocks:
-      end_stone: 1
+      stone: 1 


### PR DESCRIPTION
removed orbfuscation sections for nether and end - not present/enabled in old config
enabled fastgaze and set proximity distance to 8
readded jukes noteblocks and sponges to proximity, also added bone blocks
proximity uses block below by default, this seems desirable so the end and overworld can share a config
added air to orebfuscation