### PR TITLE
Add website to visit for pearled info

### DIFF
--- a/templates/public/plugins/ExilePearl/config.yml.j2
+++ b/templates/public/plugins/ExilePearl/config.yml.j2
@@ -61,6 +61,7 @@ help_item:
   - "<n>Another player has imprisoned you in an ender pearl."
   - "<n>Your in-game actions will be limited until you are freed."
   - "<n>You can type <c>/ep locate to see the location of your pearl."
+  - "<n>Visit civclassic.com/exilepearl for more information."
 damage_log:
   enabled: true
   algorithm: 0


### PR DESCRIPTION
To satisfy https://github.com/CivClassic/ExilePearl/issues/58 , I think it would make more sense to leverage the wealth of knowledge available on the CivWiki rather than adding more cumbersome in-game guides