### PR TITLE
Update config.yml.j2

### DIFF
--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -75,8 +75,6 @@ proximity:
     distance: 8
     useFastGazeCheck: true
     hiddenBlocks:
-      diamond_ore: {}
-      emerald_ore: {}
       chest: {}
       ender_chest: {}
       trapped_chest: {}
@@ -98,26 +96,8 @@ proximity:
       stonecutter: {}
       hopper: {}
       spawner: {}
-      shulker_box: {}
-      white_shulker_box: {}
-      orange_shulker_box: {}
-      magenta_shulker_box: {}
-      light_blue_shulker_box: {}
-      yellow_shulker_box: {}
-      lime_shulker_box: {}
-      pink_shulker_box: {}
-      gray_shulker_box: {}
-      light_gray_shulker_box: {}
-      cyan_shulker_box: {}
-      purple_shulker_box: {}
-      blue_shulker_box: {}
-      brown_shulker_box: {}
-      green_shulker_box: {}
-      red_shulker_box: {}
-      black_shulker_box: {}
       bee_nest: {}
       beehive: {}
-      bone_block: {}
       sponge: {}
       note_block: {}
       jukebox: {}


### PR DESCRIPTION
removes shulker boxes from proximity hiding (non-existant, even if they were they spend most of their time in inventories anyway)

removes bone_block from proximity hiding
removes diamond and emerald ore from proximity hiding
(pointless to have these, only ruins people's builds)