### PR TITLE
Add a lamp black dye recipe made from charcoal

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -49,6 +49,7 @@ factories:
      - charcoal_from_acacia_log
      - charcoal_from_dark_oak_log
      - charcoal_from_coal
+     - lamp_black
      - repair_charcoal_factory
   aesthetics:
     type: FCC
@@ -1096,6 +1097,19 @@ recipes:
       charcoal:
         material: CHARCOAL
         amount: 64
+  lamp_black:
+    production_time: 4s
+    name: Make Lamp Black Dye from Charcoal
+    type: PRODUCTION
+    input:
+      log:
+        material: CHARCOAL
+        amount: 64
+    output:
+      charcoal:
+        material: BLACK_DYE
+        amount: 64
+        name: Lamp Black Dye
   make_cracked_stone_brick:
     production_time: 4s
     name: Make Cracked Stone Brick


### PR DESCRIPTION
In the Charcoal Factory, you can now make 64 black dye using 64 charcoal. 

In my opinion, black dye is too hard to obtain for building, even when mobs are enabled. Right now with basically no squids spawning there is no way to obtain black dye in bulk. 

This recipe alleviates some of the pressure by adding a way to get black dye using charcoal. However it is also somewhat balanced in the fact that ink sacs are still needed for making books, thus giving them a use that this recipe does not replace.

Reminder: In 1.13+ versions ink sacs and black dye are two seperate items. You can craft ink sacs into black dye, but not the other way around. The printing press takes specifically ink sacs.