### PR TITLE
Prevent cobblestone from quickly despawning

### DIFF
--- a/templates/public/paper.yml.j2
+++ b/templates/public/paper.yml.j2
@@ -130,7 +130,6 @@ world-settings:
     alt-item-despawn-rate:
       enabled: true
       items:
-        COBBLESTONE: 300
         DIAMOND: 36000
         DIAMOND_AXE: 36000
         DIAMOND_BLOCK: 36000


### PR DESCRIPTION
Rate was set to 300 ticks which despawns dropped cobblestone after 15 seconds. Removing cobblestone from the config should make it despawn normally 