### PR TITLE
Add impossible banner pattern recipes

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -661,6 +661,7 @@ factories:
       - repair_printer
       - craft_globe_banner_pattern
       - craft_piglin_banner_pattern
+      - craft_creeper_banner_pattern
   concrete_mixer:
     type: FCC
     name: Concrete Mixer
@@ -5440,10 +5441,37 @@ recipes:
         amount: 1
       chiseled_polished_blackstone:
         material: CHISELED_POLISHED_BLACKSTONE
-        amount: 16
+        amount: 64
     output:
       piglin_banner_pattern:
         material: PIGLIN_BANNER_PATTERN
+        amount: 1
+  craft_creeper_banner_pattern:
+    type: PRODUCTION
+    name: Craft Creeper Banner Pattern
+    production_time: 4s
+    input:
+      paper:
+        material: PAPER
+        amount: 1
+      creeper_spawn_egg:
+        material: CREEPER_SPAWN_EGG
+        amount: 2
+      trident:
+        material: TRIDENT
+        amount: 1
+      water_bucket:
+        material: WATER_BUCKET
+        amount: 1
+    output:
+      creeper_banner_pattern:
+        material: CREEPER_BANNER_PATTERN
+        amount: 1
+      trident:
+        material: TRIDENT
+        amount: 1
+      bucket:
+        material: BUCKET
         amount: 1
   repair_printer:
     forceInclude: true

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2945,7 +2945,7 @@ recipes:
         amount: 256
   make_bookshelves:
     production_time: 4s
-      name: Make Bookshelves
+    name: Make Bookshelves
     type: PRODUCTION
     input:
       paper:

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -659,6 +659,8 @@ factories:
       - print_note
       - print_secure_note
       - repair_printer
+      - craft_globe_banner_pattern
+      - craft_piglin_banner_pattern
   concrete_mixer:
     type: FCC
     name: Concrete Mixer
@@ -5404,7 +5406,7 @@ recipes:
       plate:
         material: OAK_TRAPDOOR
         amount: 1
-  globe_banner:
+  craft_globe_banner_pattern:
     type: PRODUCTION
     name: Craft Globe Banner Pattern
     production_time: 4s
@@ -5425,7 +5427,7 @@ recipes:
     villager_spawn_egg:
         material: VILLAGER_SPAWN_EGG
         amount: 1
-  piglin_banner:
+  craft_piglin_banner_pattern:
     type: PRODUCTION
     name: Craft Piglin Banner Pattern
     production_time: 4s

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2943,7 +2943,7 @@ recipes:
         amount: 256
   make_bookshelves:
     production_time: 4s
-    name: Make Bookshelves
+      name: Make Bookshelves
     type: PRODUCTION
     input:
       paper:
@@ -5403,6 +5403,45 @@ recipes:
     printingplate:
       plate:
         material: OAK_TRAPDOOR
+        amount: 1
+  globe_banner:
+    type: PRODUCTION
+    name: Craft Globe Banner Pattern
+    production_time: 4s
+    input:
+      paper:
+        material: PAPER
+        amount: 1
+      emerald_block:
+        material: EMERALD_BLOCK
+        amount: 1
+      villager_spawn_egg:
+        material: VILLAGER_SPAWN_EGG
+        amount: 1
+    output:
+      globe_banner_pattern:
+        material: GLOBE_BANNER_PATTERN
+        amount: 1
+    villager_spawn_egg:
+        material: VILLAGER_SPAWN_EGG
+        amount: 1
+  piglin_banner:
+    type: PRODUCTION
+    name: Craft Piglin Banner Pattern
+    production_time: 4s
+    input:
+      paper:
+        material: PAPER
+        amount: 1
+      gold_block:
+        material: GOLD_BLOCK
+        amount: 1
+      chiseled_polished_blackstone:
+        material: CHISELED_POLISHED_BLACKSTONE
+        amount: 16
+    output:
+      piglin_banner_pattern:
+        material: PIGLIN_BANNER_PATTERN
         amount: 1
   repair_printer:
     forceInclude: true


### PR DESCRIPTION
Two banner patterns are impossible to obtain on classics, the globe pattern that requires trading with a villager and the piglin pattern that can only be found while looting [Bastion Remnants](https://minecraft.gamepedia.com/Bastion_Remnant). This adds recipes to craft them in the Printing Press.