### PR TITLE
Allow bonemealing nylium

### DIFF
--- a/templates/public/plugins/RealisticBiomes/config.yml.j2
+++ b/templates/public/plugins/RealisticBiomes/config.yml.j2
@@ -2,8 +2,6 @@
 allow_tallplant_replication: true
 
 no_bonemeal_blocks:
-- WARPED_NYLIUM
-- CRIMSON_NYLIUM
 - SEA_PICKLE
 - KELP
 - KELP_PLANT


### PR DESCRIPTION
> Similar to grass blocks, the player can apply bone meal to nylium. This nylium, along with nearby nylium, generate vegetation that occurs in their native biome (crimson nylium generates mostly crimson forest vegetation and warped nylium generates mostly warped forest vegetation).

Is there a reason this should be disabled? Currently crimson/warped roots and nether sprouts are unobtainable