### PR TITLE
Fix DogFact

### DIFF
--- a/templates/public/plugins/SimpleAdminHacks/config.yml.j2
+++ b/templates/public/plugins/SimpleAdminHacks/config.yml.j2
@@ -91,7 +91,7 @@ hacks:
       - '["",{"text":"[CivClassic] ","color":"gold"},{"text":"Type /vote to vote for CivClassic and receive essence!","color":"green"}]'
       - '["",{"text":"[CivClassic] ","color":"gold"},{"text":"Gold blocks work as elevators, shift to go down and spacebar to go up","color":"green"}]'
       - '["",{"text":"[CivClassic] ","color":"gold"},{"text":"For the best experience use 1.16.4 - other versions are not officially supported","color":"green"}]'
-      - '["",{"text":"[CivClassic] ","color":"gold"},{"text":"Don't put buttons or signs over an elevator - or it will be blocked and you won't be able to teleport back to that block!","color":"green"}]'
+      - '["",{"text":"[CivClassic] ","color":"gold"},{"text":"Dont put buttons or signs over an elevator - or it will be blocked and you wont be able to teleport back to that block!","color":"green"}]'
   EventDebugHack:
     enabled: true
   EventHandlerList:


### PR DESCRIPTION
We cant use apostrophe's without escape characters since we use them to encase the string