### PR TITLE
Create github action to lint YAML

### DIFF
--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -1,0 +1,24 @@
+name: Lint YAML
+
+on: [push]
+
+jobs:
+  lint-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: lint-yaml
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: .
+          config_data: |
+            extends: default
+            yaml-files:
+              - '*.yaml'
+              - '*.yml'
+              - '*.yml.j2'
+            rules:
+              trailing-spaces:
+                level: warning
+              line-length:
+                level: warning


### PR DESCRIPTION
I left almost all the rules for the lint default aside from making line length and trailing spaces warnings instead of errors, but the rules are up to you obviously.

Because this PR is only creating the workflow, the workflow will not pass initially because of pre-existing validation errors that should be fixed after merging.

Rules for the config_data block can be found [here](https://yamllint.readthedocs.io/en/stable/rules.html), let me know if you want any of them changed for this PR.

Closes #108 