### PR TITLE
Mildly Reduce Mob Despawning

### DIFF
--- a/templates/public/paper.yml.j2
+++ b/templates/public/paper.yml.j2
@@ -174,9 +174,12 @@ world-settings:
     fishing-time-range:
       MinimumTicks: 100
       MaximumTicks: 600
+    #Manages despawns via location of a player
+    #soft = slow passive deletions
+    #hard = instant deletion
     despawn-ranges:
-      soft: 32
-      hard: 128
+      soft: 64
+      hard: 100
     lightning-strike-distance-limit:
       sound: -1
       impact-sound: -1


### PR DESCRIPTION
32 blocks for passive despawning is far too low :/
We double it, since it will only increase the total amount of mobs spawned by ~25% (mobs currently are no issue in regards to server memory or processing.)
However just in-case we'll reduce hard-despawn to 100.