### PR TITLE
Alt-item despawn changes

### DIFF
--- a/templates/public/paper.yml.j2
+++ b/templates/public/paper.yml.j2
@@ -130,7 +130,7 @@ world-settings:
     alt-item-despawn-rate:
       enabled: true
       items:
-        COBBLESTONE: 6000
+        COBBLESTONE: 600
         DIAMOND: 36000
         DIAMOND_AXE: 36000
         DIAMOND_BLOCK: 36000
@@ -142,12 +142,36 @@ world-settings:
         DIAMOND_PICKAXE: 36000
         DIAMOND_SHOVEL: 36000
         DIAMOND_SWORD: 36000
+        NETHERITE_INGOT: 36000
+        NETHERITE_AXE: 36000
+        NETHERITE_BLOCK: 36000
+        NETHERITE_BOOTS: 36000
+        NETHERITE_CHESTPLATE: 36000
+        NETHERITE_HELMET: 36000
+        NETHERITE_LEGGINGS: 36000
+        ANCIENT_DEBRIS: 36000
+        NETHERITE_PICKAXE: 36000
+        NETHERITE_SHOVEL: 36000
+        NETHERITE_SWORD: 36000
         EMERALD_BLOCK: 36000
         EMERALD: 36000
         IRON_BLOCK: 36000
         SPONGE: 36000
         BONE_BLOCK: 36000
         JUKEBOX: 36000
+        GRASS: 600
+        STONE: 600
+        STONE_AXE: 3000
+        STONE_PICKAXE: 3000
+        STONE_SWORD: 3000
+        WOODEN_AXE: 3000
+        WOODEN_PICKAXE: 3000
+        WOODEN_SWORD: 3000
+        GRAVEL: 600
+        DIRT: 600
+        ANDESITE: 600
+        DIORITE: 600
+        GRANITE: 600
     game-mechanics:
       nerf-pigmen-from-nether-portals: false
       disable-pillager-patrols: true


### PR DESCRIPTION
Adding Netherite update items so they don't despawn quickly.

Drastically lowered time to cause cobblestone to despawn (600 = 30 seconds, was previously at 6000, or 5m... which is default)
Added in other common drops that don't get picked up while mining dirt or stone.