### PR TITLE
Allow "illegal access"

### DIFF
--- a/templates/public/start.sh.j2
+++ b/templates/public/start.sh.j2
@@ -22,4 +22,5 @@ java -server \
  -Dusing.aikars.flags=https://mcflags.emc.gs \
  -Daikars.new.flags=true -jar \
  -Xmx{{ shard_mem }} -Xms{{ shard_mem }} \
+ --illegal-access=permit \
  -jar {{ server_jar }}.jar nogui


### PR DESCRIPTION
Prevents warnings and errors from ProtocolLib for perfectly ordinary uses of reflection that Java is attempting to clamp down on.