### PR TITLE
Make uncarving pumpkins consume no fuel

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -4376,6 +4376,7 @@ recipes:
   uncarve_pumpkins:
     forceInclude: true
     production_time: 1s
+    fuel_consumption_intervall: 99999s
     name: Uncarve Pumpkins
     type: PRODUCTION
     input:
@@ -4389,6 +4390,7 @@ recipes:
   uncarve_compacted_pumpkins:
     forceInclude: true
     production_time: 1s
+    fuel_consumption_intervall: 99999s
     name: Uncarve Pumpkins
     type: PRODUCTION
     input:


### PR DESCRIPTION
According to a conversation I had in globalchat, the recipe is currently consuming fuel, at a rate of 1 charcoal per pumpkin. This seems to have been an oversight.

This change makes uncarving pumpkins take no fuel.