### PR TITLE
Drastically increase voting rewards

### DIFF
--- a/templates/public/plugins/EssenceGlue/config.yml.j2
+++ b/templates/public/plugins/EssenceGlue/config.yml.j2
@@ -21,7 +21,7 @@ voting_reward:
   essence:
      material: ENDER_EYE
      name: Player Essence
-     amount: 1
+     amount: 5
      lore:
       - Activity reward used to fuel pearls
 


### PR DESCRIPTION
Daily login shouldn't be nearly 3x voting rewards at full streak.

5 per site gives a max daily essence reward of 23, compared to current 11 essence max.

But let's be real, few people will vote, so average max across players will be 15 but this gives people some actual incentive to vote.