### PR TITLE
Reduce Cobble->Gravel and Gravel->Sand outputs

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -5740,7 +5740,7 @@ recipes:
     output:
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 8
   crush_gravel:
     production_time: 4s
     name: Crush Gravel
@@ -5752,7 +5752,7 @@ recipes:
     output:
       sand:
         material: SAND
-        amount: 32
+        amount: 8
   grind_sandstone:
     production_time: 4s
     name: Grind Sandstone


### PR DESCRIPTION
Given the vast impact this is having on sand and gravel markets, the factory exchange rate between cobble, gravel, and sand is too even.. and charcoal costs are irrelevant given how incredibly cheap and bottable wood is.