### PR TITLE
black dye removal

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -53,7 +53,6 @@ factories:
      - charcoal_from_acacia_log
      - charcoal_from_dark_oak_log
      - charcoal_from_coal
-     - lamp_black
      - repair_charcoal_factory
   aesthetics:
     type: FCC
@@ -1236,18 +1235,6 @@ recipes:
     output:
       charcoal:
         material: CHARCOAL
-        amount: 64
-  lamp_black:
-    production_time: 4s
-    name: Make Lamp Black Dye from Charcoal
-    type: PRODUCTION
-    input:
-      log:
-        material: CHARCOAL
-        amount: 64
-    output:
-      charcoal:
-        material: BLACK_DYE
         amount: 64
   make_quartz:
     production_time: 4s


### PR DESCRIPTION
Remove black dye recipe, it was added because squids were not spawning, and the recipes addition nerfed a niche market. squids are now plentiful.