### PR TITLE
[1.17] Disable "bugged" obsidian generation

### DIFF
--- a/templates/public/plugins/SimpleAdminHacks/config.yml.j2
+++ b/templates/public/plugins/SimpleAdminHacks/config.yml.j2
@@ -272,7 +272,7 @@ hacks:
       playerKill: 5
     blockWaterInHell: true
     minecartTeleport: true
-    obsidianGenerators: true
+    obsidianGenerators: false
     personalDeathMessages: false
     disableNetheriteCrafting: false
     goldBlockTeleport: false


### PR DESCRIPTION
So the whole string to obsidian generator thing is, iirc, a bug that became a feature to help with bulk obsidian generation. I don't know the actual history so that's my abridged version. *Anyway,* in 1.17 you can use dripstones below a lava source to drip lava into a cauldron to produce what I assume to be infinite lava, thus bulk obsidian generation can return to a more vanilla, minecrafty way that also happens to be more accessible to newfriends.