### PR TITLE
Remove Uncarve [Compacted] Pumpkins

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -716,7 +716,6 @@ factories:
      - adv_xp_5
      - adv_xp_6
      - uncarve_pumpkins
-     - uncarve_compacted_pumpkins
      - wither_skull
      - make_energizer
      - repair_advanced_cauldron
@@ -4578,23 +4577,6 @@ recipes:
       pumpkins:
         material: PUMPKIN
         amount: 64
-  uncarve_compacted_pumpkins:
-    forceInclude: true
-    production_time: 1s
-    name: Uncarve Pumpkins
-    type: PRODUCTION
-    input:
-      carved_pumpkins:
-        material: CARVED_PUMPKIN
-        amount: 8
-        lore:
-          - Compacted Item
-    output:
-      pumpkins:
-        material: PUMPKIN
-        amount: 8
-        lore:
-          - Compacted Item
   make_bell:
     forceInclude: true
     production_time: 4s


### PR DESCRIPTION
Since Wing's [commit](https://github.com/CivClassic/AnsibleSetup/commit/bd24ac3dd988dc07db1dcb5778dd712496d2c64c) that makes uncarving pumpkins 64x cheaper, this compacted variant should be removed. This recipe is singularly irregular, it's the only non-XP related recipe that processes compacted items, which fundamentally undermines the balancing of compaction; that XP recipes require compacted items because you simply cannot store that many items in a double chest, it's a necessity.. but uncarving pumpkins?