### PR TITLE
Change how xp is made

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -28,6 +28,7 @@ factories:
      - smelt_cracked_stone_bricks
      - smelt_glass
      - smelt_glass_red
+     - smelt_xp_bottle
      - smelt_netherrack
      - smelt_red_netherbrick
      - smelt_bricks
@@ -1181,6 +1182,29 @@ recipes:
       glass:
         material: GLASS
         amount: 128
+  smelt_xp_bottle
+    name: Smelt Bottles for XP
+    production_time: 4s
+    input:
+      glass:
+        material: GLASS
+        amount: 192
+      clay:
+        material: CLAY_BALL
+        amount: 16
+      essence:
+        material: ENDER_EYE
+        amount: 1
+        name: Player Essence
+        lore:
+          - Activity reward used to fuel pearls
+    output:
+      glass_bottle:
+        material: GLASS_BOTTLE
+        amount: 192
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
   smelt_netherrack:
     production_time: 4s
     name: Smelt Netherrack
@@ -4900,6 +4924,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 24
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       carrot:
         material: CARROT
         amount: 256
@@ -4921,6 +4948,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 14
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       carrot:
         material: CARROT
         amount: 256
@@ -4942,6 +4972,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 42
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       carrot:
         material: CARROT
         amount: 128
@@ -4972,6 +5005,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 42
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       nether_wart:
         material: NETHER_WART
         amount: 256
@@ -5027,6 +5063,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       carrot:
         material: CARROT
         amount: 96
@@ -5066,6 +5105,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       nether_wart:
         material: NETHER_WART
         amount: 64
@@ -5105,6 +5147,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       wheat:
         material: WHEAT
         amount: 128
@@ -5144,6 +5189,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
+        lore:
+          - Used in the creation of XP
       nether_wart:
         material: NETHER_WART
         amount: 64
@@ -5201,7 +5249,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
         lore:
+          - Used in the creation of XP
           - Compacted Item
       carrot:
         material: CARROT
@@ -5262,7 +5312,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
         lore:
+          - Used in the creation of XP
           - Compacted Item
       nether_wart:
         material: NETHER_WART
@@ -5323,7 +5375,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
         lore:
+          - Used in the creation of XP
           - Compacted Item
       wheat:
         material: WHEAT
@@ -5384,7 +5438,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
         lore:
+          - Used in the creation of XP
           - Compacted Item
       nether_wart:
         material: NETHER_WART
@@ -5445,7 +5501,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
         lore:
+          - Used in the creation of XP
           - Compacted Item
       carrot:
         material: CARROT
@@ -5506,7 +5564,9 @@ recipes:
       glass_bottle:
         material: GLASS_BOTTLE
         amount: 128
+        name: Empty XP Bottle
         lore:
+          - Used in the creation of XP
           - Compacted Item
       wheat:
         material: WHEAT


### PR DESCRIPTION
An alternative to nerfing the grinding mill, xp requires a lored bottle, that itself needs essence and clay in it's creation

Input 192 glass, 16 clay balls, 1 essence
output 192 lored bottles required for xp recipes