### PR TITLE
Fix grinding mill nerf cancellation

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -5954,7 +5954,7 @@ recipes:
         amount: 64
     output:
       red sand:
-        material: SAND
+        material: RED_SAND
         amount: 64
   repair_grinding_mill:
     production_time: 4s


### PR DESCRIPTION
I'm not quite sure what the problem was, but people have been reporting that the grinding mill nerf is still in effect despite its supposed cancellation 5 days ago; I've copied the exact configs for the seven grinding mill recipes from the last pre-nerf factorymod commit, so whatever was wrong, this should fix it.