### PR TITLE
Make netherite pickaxes cost three times fewer netherite ingots

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -1612,7 +1612,7 @@ recipes:
     input:
       netherite:
         material: NETHERITE_INGOT
-        amount: 3
+        amount: 1
       diamond:
         material: DIAMOND
         amount: 6


### PR DESCRIPTION
Currently you make 29% fewer net diamonds per time mining ancient debris in the hell biome with the netherite pickaxe, compared to the diamond pickaxe. This would make netherite pickaxes 1.4% better than diamond pickaxes.

Alternatively changing the ore bonus for netherite pickaxes to 45% would make them 2.2% better (50% is 7.3% better)