### PR TITLE
Increase rates of ancient debris in the nether biome

### DIFF
--- a/templates/public/plugins/HiddenOre/config.yml.j2
+++ b/templates/public/plugins/HiddenOre/config.yml.j2
@@ -263,7 +263,7 @@ drops:
       transformIfAble: true
       biomes:
          NETHER_WASTES:
-            chance: 0.0018
+            chance: 0.006
    emerald_ore_dank:
       package:
       -  ==: org.bukkit.inventory.ItemStack


### PR DESCRIPTION
This would put the amount of money you make in a nether biome on par with what you make mining stone, and make netherite pickaxes 2.1% better to use, rather than 29% worse.

I would also slightly decrease the cost of repair (maybe the recipe for making netherite pickaxes makes 9 pickaxes instead of 8)

This would also change the nether biome from being five times worse to mine in to two times worse to mine in (when only counting diamond and netherite) per block break