### PR TITLE
Add in multiple layers of enderchests relay for shops

### DIFF
--- a/templates/public/plugins/ItemExchange/config.yml.j2
+++ b/templates/public/plugins/ItemExchange/config.yml.j2
@@ -83,7 +83,7 @@ shopRelay:
   relayBlocks:
     - "ENDER_CHEST"
   # Determines how many times a relay can be relayed
-  recursionLimit: 0
+  recursionLimit: 3
   # Determines how far (in blocks) a relay can search
   reachDistance: 4
   # Determines which blocks will be ignored by relays (wont end the search for shops)


### PR DESCRIPTION
I don't get why this is a setting, already coded, and not used?

It allows for actual wealth investment in shops, even if you relay a shop chest 3times, you still need to invest 12d in the glass, 3d in the enderchests, and then surround that relay with even more layers of DRO to make it worthwhile. (60d in obby on first layer, and you'd want each successive relay to have another additional layer of dro on it) A single secure relay system could *easily* cost 300d.