### PR TITLE
Re-Add 2:00 Minute Drinkable Regen

### DIFF
--- a/templates/public/plugins/Finale/config.yml.j2
+++ b/templates/public/plugins/Finale/config.yml.j2
@@ -200,6 +200,13 @@ potions:
 #All splash pots reduced
       splash: true
       multiplier: 1.0
+#2:00 Minute Drinkable Regen, like pre-update.      
+    regen:
+      type: REGEN
+      splash: false
+      upgraded: true
+      extended: false
+      multiplier: 1.3
 #Except for health
     health:
       type: INSTANT_HEAL


### PR DESCRIPTION
This was apparently removed post-update. Something that must've been missed in the Humbug update but was never re-added here.

Edit: If people need confirmation that this was a future prior to the update, here's a video https://youtu.be/4uWbINGMeSY at 2:47 shows functionality as intended.