### PR TITLE
Add lapis back to enchanting

### DIFF
--- a/templates/public/plugins/SimpleAdminHacks/config.yml.j2
+++ b/templates/public/plugins/SimpleAdminHacks/config.yml.j2
@@ -132,7 +132,7 @@ hacks:
     # Hides what enchantment will be granted within the Enchanting Table
     hideEnchants: true
     # Automatically fills the consumable slot with the Enchanting Table with Lapis Lazuli that cannot be taken
-    fillLapis: true
+    fillLapis: false
     # Randomises the enchantment offers each time the item is placed in an Enchanting Table
     randomiseEnchants: true
     # Force enchantments to cost what they appear in the Enchanting Table


### PR DESCRIPTION
Add lapis back to enchanting - don't know why we're still clutching our pearls over lapis being added to enchanting tables back in 1.8 which happened over 6 years ago.