### PR TITLE
Rollback piston changes, it didn't work

### DIFF
--- a/templates/public/plugins/SimpleAdminHacks/config.yml.j2
+++ b/templates/public/plugins/SimpleAdminHacks/config.yml.j2
@@ -330,11 +330,11 @@ hacks:
       exceededMessage: '&9Limit (%Limit%) reached for this chunk, you cannot place more of this type of block (%Material%).'
       tileEntities:
         HOPPER: 16
-        PISTON: 50 # Limiting pistons doesn't actually work, because all the blocks being moved are counted as the piston entities
-        STICKY_PISTON: 50 # So this just makes it so you can't have flying machines, etc 
-        MOVING_PISTON: 50 # Without actually stopping placement of pistons
-        PISTON_HEAD: 50
-        OBSERVER: 50
+#        PISTON: 50 Limiting pistons doesn't actually work, because all the blocks being moved are counted as the piston entities
+#        STICKY_PISTON: 50 So this just makes it so you can't have flying machines, etc 
+#        MOVING_PISTON: 50 Without actually stopping placement of pistons
+#        PISTON_HEAD: 50 Adding any of these to this list disallows pistons from pushing them for some reason. 
+#        OBSERVER: 50 Totally killing flying machines, they won't even start. https://github.com/CivClassic/AnsibleSetup/issues/237
         DISPENSER: 16
         DROPPER: 16
         COMPARATOR: 12


### PR DESCRIPTION
Adding the piston changes made it so pistons could no longer move observers, totally breaking flying machines and destroying redstone applications.