### PR TITLE
a slight buff to forest biomes

### DIFF
--- a/templates/public/plugins/RealisticBiomes/config.yml.j2
+++ b/templates/public/plugins/RealisticBiomes/config.yml.j2
@@ -142,6 +142,7 @@ plants:
       nether: 0.5
       end: 0.5
       cold: 0.25
+      cold_forest: 0.25
       hot_dry: 0.25
       mountain: 0.25
       mesa: 0.25
@@ -181,6 +182,7 @@ plants:
       SOUL_TORCH: 0.1
     biomes:
       hot_rainy: 1.0
+      foresty: 0.75
       swampy: 0.5
       temperate: 0.25
       hot_dry: 0.1
@@ -218,6 +220,7 @@ plants:
       mountain: 1.0
       temperate: 0.5
       cold: 0.25
+      cold_forest: 0.25
       mesa: 0.1
       nether: 0.1
       end: 0.1
@@ -255,6 +258,7 @@ plants:
       nether: 0.5
       end: 0.5
       cold: 0.25
+      cold_forest: 0.25
       hot_dry: 0.25
       mesa: 0.25
       mountain: 0.25
@@ -358,6 +362,7 @@ plants:
       swampy: 1.0
       hot_rainy: 0.5
       temperate: 0.25
+      foresty: 0.25
 
   MELON_STEM:
     persistent_growth_period: 0
@@ -387,6 +392,7 @@ plants:
       swampy: 1.0
       hot_rainy: 0.5
       temperate: 0.25
+      foresty: 0.25
 
   PUMPKIN:
     persistent_growth_period: 0
@@ -420,6 +426,7 @@ plants:
     biomes:
       cold: 1.0
       mountain: 1.0
+      cold_forest: 0.75
       temperate: 0.25
 
   PUMPKIN_STEM:
@@ -449,6 +456,7 @@ plants:
     biomes:
       cold: 1.0
       mountain: 1.0
+      cold_forest: 0.75
       temperate: 0.25
 
 # formerly inheriting Column properties
@@ -666,6 +674,7 @@ plants:
       foresty: 1.0
       cold_forest: 0.5
       freshwater: 0.5
+
 
 database:
   ==: vg.civcraft.mc.civmodcore.dao.ManagedDatasource


### PR DESCRIPTION
In the current config, the Forest and Cold Forest biomes are so extremely underwhelming in terms of farming potential that's they're essentially respectively white and green wasteland which you effectively cannot settle in. This is problematic as Forest is one of the biggest biomes in terms of size and its currently less useful than Desert in terms of xp crops. 

I think the forest needs a slight buff to make it actually viable to settle in.

This PR proposes that Forest gets:
4h carrots 
25% melon growth 

And cold forest gets the same grow rates as the regular cold biomes, with the exception of pumpkins being nerfed 25% compared to the regular cold biomes.


