### PR TITLE
Concrete Factory Rebalance

### DIFF
--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2710,12 +2710,12 @@ recipes:
     name: Mix White Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       white_dye:
         material: WHITE_DYE
         amount: 4
@@ -2728,12 +2728,12 @@ recipes:
     name: Mix Orange Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       orange_dye:
         material: ORANGE_DYE
         amount: 4
@@ -2746,12 +2746,12 @@ recipes:
     name: Mix Magenta Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       magenta_dye:
         material: MAGENTA_DYE
         amount: 4
@@ -2764,12 +2764,12 @@ recipes:
     name: Mix Light Blue Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       light_blue_dye:
         material: LIGHT_BLUE_DYE
         amount: 4
@@ -2782,12 +2782,12 @@ recipes:
     name: Mix Yellow Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       yellow_dye:
         material: YELLOW_DYE
         amount: 4
@@ -2800,12 +2800,12 @@ recipes:
     name: Mix Lime Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       lime_dye:
         material: LIME_DYE
         amount: 4
@@ -2818,12 +2818,12 @@ recipes:
     name: Mix Pink Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       pink_dye:
         material: PINK_DYE
         amount: 4
@@ -2836,12 +2836,12 @@ recipes:
     name: Mix Gray Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       gray_dye:
         material: GRAY_DYE
         amount: 4
@@ -2854,12 +2854,12 @@ recipes:
     name: Mix Light Gray Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       light_gray_dye:
         material: LIGHT_GRAY_DYE
         amount: 4
@@ -2872,12 +2872,12 @@ recipes:
     name: Mix Cyan Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       cyan_dye:
         material: CYAN_DYE
         amount: 4
@@ -2890,12 +2890,12 @@ recipes:
     name: Mix Purple Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       purple_dye:
         material: PURPLE_DYE
         amount: 4
@@ -2908,12 +2908,12 @@ recipes:
     name: Mix Blue Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       blue_dye:
         material: BLUE_DYE
         amount: 4
@@ -2926,12 +2926,12 @@ recipes:
     name: Mix Brown Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       brown_dye:
         material: BROWN_DYE
         amount: 4
@@ -2944,12 +2944,12 @@ recipes:
     name: Mix Green Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       green_dye:
         material: GREEN_DYE
         amount: 4
@@ -2962,12 +2962,12 @@ recipes:
     name: Mix Red Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       red_dye:
         material: RED_DYE
         amount: 4
@@ -2980,12 +2980,12 @@ recipes:
     name: Mix Black Concrete
     type: PRODUCTION
     input:
-      stone:
-        material: STONE
-        amount: 64
-      egg:
-        material: EGG
-        amount: 1
+      sand:
+        material: SAND
+        amount: 32
+      gravel:
+        material: GRAVEL
+        amount: 32
       black_dye:
         material: BLACK_DYE
         amount: 4

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2694,12 +2694,12 @@ recipes:
     name: Mix White Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       white_dye:
         material: WHITE_DYE
         amount: 4
@@ -2712,12 +2712,12 @@ recipes:
     name: Mix Orange Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       orange_dye:
         material: ORANGE_DYE
         amount: 4
@@ -2730,12 +2730,12 @@ recipes:
     name: Mix Magenta Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       magenta_dye:
         material: MAGENTA_DYE
         amount: 4
@@ -2748,12 +2748,12 @@ recipes:
     name: Mix Light Blue Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       light_blue_dye:
         material: LIGHT_BLUE_DYE
         amount: 4
@@ -2766,12 +2766,12 @@ recipes:
     name: Mix Yellow Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       yellow_dye:
         material: YELLOW_DYE
         amount: 4
@@ -2784,12 +2784,12 @@ recipes:
     name: Mix Lime Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       lime_dye:
         material: LIME_DYE
         amount: 4
@@ -2802,12 +2802,12 @@ recipes:
     name: Mix Pink Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       pink_dye:
         material: PINK_DYE
         amount: 4
@@ -2820,12 +2820,12 @@ recipes:
     name: Mix Gray Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       gray_dye:
         material: GRAY_DYE
         amount: 4
@@ -2838,12 +2838,12 @@ recipes:
     name: Mix Light Gray Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       light_gray_dye:
         material: LIGHT_GRAY_DYE
         amount: 4
@@ -2856,12 +2856,12 @@ recipes:
     name: Mix Cyan Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       cyan_dye:
         material: CYAN_DYE
         amount: 4
@@ -2874,12 +2874,12 @@ recipes:
     name: Mix Purple Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       purple_dye:
         material: PURPLE_DYE
         amount: 4
@@ -2892,12 +2892,12 @@ recipes:
     name: Mix Blue Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       blue_dye:
         material: BLUE_DYE
         amount: 4
@@ -2910,12 +2910,12 @@ recipes:
     name: Mix Brown Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       brown_dye:
         material: BROWN_DYE
         amount: 4
@@ -2928,12 +2928,12 @@ recipes:
     name: Mix Green Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       green_dye:
         material: GREEN_DYE
         amount: 4
@@ -2946,12 +2946,12 @@ recipes:
     name: Mix Red Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       red_dye:
         material: RED_DYE
         amount: 4
@@ -2964,12 +2964,12 @@ recipes:
     name: Mix Black Concrete
     type: PRODUCTION
     input:
-      sand:
-        material: SAND
-        amount: 32
-      gravel:
-        material: GRAVEL
-        amount: 32
+      stone:
+        material: STONE
+        amount: 64
+      egg:
+        material: EGG
+        amount: 1
       black_dye:
         material: BLACK_DYE
         amount: 4

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2712,10 +2712,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       white_dye:
         material: WHITE_DYE
         amount: 4
@@ -2730,10 +2730,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       orange_dye:
         material: ORANGE_DYE
         amount: 4
@@ -2748,10 +2748,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       magenta_dye:
         material: MAGENTA_DYE
         amount: 4
@@ -2766,10 +2766,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       light_blue_dye:
         material: LIGHT_BLUE_DYE
         amount: 4
@@ -2784,10 +2784,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       yellow_dye:
         material: YELLOW_DYE
         amount: 4
@@ -2802,10 +2802,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       lime_dye:
         material: LIME_DYE
         amount: 4
@@ -2820,10 +2820,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       pink_dye:
         material: PINK_DYE
         amount: 4
@@ -2838,10 +2838,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       gray_dye:
         material: GRAY_DYE
         amount: 4
@@ -2856,10 +2856,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       light_gray_dye:
         material: LIGHT_GRAY_DYE
         amount: 4
@@ -2874,10 +2874,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       cyan_dye:
         material: CYAN_DYE
         amount: 4
@@ -2892,10 +2892,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       purple_dye:
         material: PURPLE_DYE
         amount: 4
@@ -2910,10 +2910,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       blue_dye:
         material: BLUE_DYE
         amount: 4
@@ -2928,10 +2928,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       brown_dye:
         material: BROWN_DYE
         amount: 4
@@ -2946,10 +2946,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       green_dye:
         material: GREEN_DYE
         amount: 4
@@ -2964,10 +2964,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       red_dye:
         material: RED_DYE
         amount: 4
@@ -2982,10 +2982,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 18
+        amount: 16
       gravel:
         material: GRAVEL
-        amount: 24
+        amount: 16
       black_dye:
         material: BLACK_DYE
         amount: 4
@@ -2994,7 +2994,7 @@ recipes:
         material: BLACK_CONCRETE_POWDER
         amount: 64
   harden_concrete_white:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden White Concrete
     type: PRODUCTION
@@ -3013,7 +3013,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_orange:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Orange Concrete
     type: PRODUCTION
@@ -3032,7 +3032,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_magenta:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Magenta Concrete
     type: PRODUCTION
@@ -3051,7 +3051,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_light_blue:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Light Blue Concrete
     type: PRODUCTION
@@ -3070,7 +3070,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_yellow:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Yellow Concrete
     type: PRODUCTION
@@ -3089,7 +3089,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_lime:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Lime Concrete
     type: PRODUCTION
@@ -3108,7 +3108,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_pink:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Pink Concrete
     type: PRODUCTION
@@ -3127,7 +3127,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_gray:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Gray Concrete
     type: PRODUCTION
@@ -3146,7 +3146,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_light_gray:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Light Gray Concrete
     type: PRODUCTION
@@ -3165,7 +3165,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_cyan:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Cyan Concrete
     type: PRODUCTION
@@ -3184,7 +3184,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_purple:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Purple Concrete
     type: PRODUCTION
@@ -3203,7 +3203,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_blue:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Blue Concrete
     type: PRODUCTION
@@ -3222,7 +3222,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_brown:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Brown Concrete
     type: PRODUCTION
@@ -3241,7 +3241,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_green:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Green Concrete
     type: PRODUCTION
@@ -3260,7 +3260,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_red:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Red Concrete
     type: PRODUCTION
@@ -3279,7 +3279,7 @@ recipes:
         materia: BUCKET
         amount: 1
   harden_concrete_black:
-    production_time: 1s
+    production_time: 4s
     fuel_consumption_intervall: 99999s
     name: Harden Black Concrete
     type: PRODUCTION

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2718,7 +2718,7 @@ recipes:
         amount: 24
       white_dye:
         material: WHITE_DYE
-        amount: 2
+        amount: 4
     output:
       white_concrete:
         material: WHITE_CONCRETE_POWDER
@@ -2736,7 +2736,7 @@ recipes:
         amount: 24
       orange_dye:
         material: ORANGE_DYE
-        amount: 2
+        amount: 4
     output:
       orange_concrete:
         material: ORANGE_CONCRETE_POWDER
@@ -2754,7 +2754,7 @@ recipes:
         amount: 24
       magenta_dye:
         material: MAGENTA_DYE
-        amount: 2
+        amount: 4
     output:
       magenta_concrete:
         material: MAGENTA_CONCRETE_POWDER
@@ -2772,7 +2772,7 @@ recipes:
         amount: 24
       light_blue_dye:
         material: LIGHT_BLUE_DYE
-        amount: 2
+        amount: 4
     output:
       light_blue_concrete:
         material: LIGHT_BLUE_CONCRETE_POWDER
@@ -2790,7 +2790,7 @@ recipes:
         amount: 24
       yellow_dye:
         material: YELLOW_DYE
-        amount: 2
+        amount: 4
     output:
       yellow_concrete:
         material: YELLOW_CONCRETE_POWDER
@@ -2808,7 +2808,7 @@ recipes:
         amount: 24
       lime_dye:
         material: LIME_DYE
-        amount: 2
+        amount: 4
     output:
       lime_concrete:
         material: LIME_CONCRETE_POWDER
@@ -2826,7 +2826,7 @@ recipes:
         amount: 24
       pink_dye:
         material: PINK_DYE
-        amount: 2
+        amount: 4
     output:
       pink_concrete:
         material: PINK_CONCRETE_POWDER
@@ -2844,7 +2844,7 @@ recipes:
         amount: 24
       gray_dye:
         material: GRAY_DYE
-        amount: 2
+        amount: 4
     output:
       gray_concrete:
         material: GRAY_CONCRETE_POWDER
@@ -2862,7 +2862,7 @@ recipes:
         amount: 24
       light_gray_dye:
         material: LIGHT_GRAY_DYE
-        amount: 2
+        amount: 4
     output:
       light_gray_concrete:
         material: LIGHT_GRAY_CONCRETE_POWDER
@@ -2880,7 +2880,7 @@ recipes:
         amount: 24
       cyan_dye:
         material: CYAN_DYE
-        amount: 2
+        amount: 4
     output:
       cyan_concrete:
         material: CYAN_CONCRETE_POWDER
@@ -2898,7 +2898,7 @@ recipes:
         amount: 24
       purple_dye:
         material: PURPLE_DYE
-        amount: 2
+        amount: 4
     output:
       purple_concrete:
         material: PURPLE_CONCRETE_POWDER
@@ -2916,7 +2916,7 @@ recipes:
         amount: 24
       blue_dye:
         material: BLUE_DYE
-        amount: 2
+        amount: 4
     output:
       blue_concrete:
         material: BLUE_CONCRETE_POWDER
@@ -2934,7 +2934,7 @@ recipes:
         amount: 24
       brown_dye:
         material: BROWN_DYE
-        amount: 2
+        amount: 4
     output:
       brown_concrete:
         material: BROWN_CONCRETE_POWDER
@@ -2952,7 +2952,7 @@ recipes:
         amount: 24
       green_dye:
         material: GREEN_DYE
-        amount: 2
+        amount: 4
     output:
       green_concrete:
         material: GREEN_CONCRETE_POWDER
@@ -2970,7 +2970,7 @@ recipes:
         amount: 24
       red_dye:
         material: RED_DYE
-        amount: 2
+        amount: 4
     output:
       red_concrete:
         material: RED_CONCRETE_POWDER
@@ -2988,7 +2988,7 @@ recipes:
         amount: 24
       black_dye:
         material: BLACK_DYE
-        amount: 2
+        amount: 4
     output:
       black_concrete:
         material: BLACK_CONCRETE_POWDER

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -792,6 +792,22 @@ factories:
      - mix_concrete_green
      - mix_concrete_red
      - mix_concrete_black
+     - harden_concrete_white
+     - harden_concrete_orange
+     - harden_concrete_magenta
+     - harden_concrete_light_blue
+     - harden_concrete_yellow
+     - harden_concrete_lime
+     - harden_concrete_pink
+     - harden_concrete_gray
+     - harden_concrete_light_gray
+     - harden_concrete_cyan
+     - harden_concrete_purple
+     - harden_concrete_blue
+     - harden_concrete_brown
+     - harden_concrete_green
+     - harden_concrete_red
+     - harden_concrete_black
      - repair_mixer
   gold_forge:
     type: FCC
@@ -2977,6 +2993,310 @@ recipes:
       black_concrete:
         material: BLACK_CONCRETE_POWDER
         amount: 64
+  harden_concrete_white:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden White Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: WHITE_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: WHITE_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_orange:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Orange Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: ORANGE_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: ORANGE_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_magenta:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Magenta Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: MAGENTA_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: MAGENTA_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_light_blue:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Light Blue Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: LIGHT_BLUE_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: LIGHT_BLUE_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_yellow:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Yellow Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: YELLOW_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: YELLOW_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_lime:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Lime Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: LIME_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: LIME_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_pink:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Pink Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: PINK_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: PINK_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_gray:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Gray Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: GRAY_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: GRAY_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_light_gray:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Light Gray Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: LIGHT_GRAY_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: LIGHT_GRAY_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_cyan:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Cyan Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: CYAN_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: CYAN_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_purple:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Purple Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: PURPLE_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: PURPLE_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_blue:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Blue Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: BLUE_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: BLUE_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_brown:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Brown Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: BROWN_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: BROWN_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_green:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Green Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: GREEN_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: GREEN_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_red:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Red Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: RED_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: RED_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
+  harden_concrete_black:
+    production_time: 1s
+    fuel_consumption_intervall: 99999s
+    name: Harden Black Concrete
+    type: PRODUCTION
+    input:
+      concrete_powder:
+        material: BLACK_CONCRETE_POWDER
+        amount: 64
+      water_bucket:
+        materia: WATER_BUCKET
+        amount: 1
+    output:
+      concrete:
+        material: BLACK_CONCRETE
+        amount: 64
+      empty_bucket:
+        materia: BUCKET
+        amount: 1
   repair_stone_smelter:
     production_time: 4s
     name: Repair Factory

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2712,10 +2712,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       white_dye:
         material: WHITE_DYE
         amount: 4
@@ -2730,10 +2730,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       orange_dye:
         material: ORANGE_DYE
         amount: 4
@@ -2748,10 +2748,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       magenta_dye:
         material: MAGENTA_DYE
         amount: 4
@@ -2766,10 +2766,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       light_blue_dye:
         material: LIGHT_BLUE_DYE
         amount: 4
@@ -2784,10 +2784,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       yellow_dye:
         material: YELLOW_DYE
         amount: 4
@@ -2802,10 +2802,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       lime_dye:
         material: LIME_DYE
         amount: 4
@@ -2820,10 +2820,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       pink_dye:
         material: PINK_DYE
         amount: 4
@@ -2838,10 +2838,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       gray_dye:
         material: GRAY_DYE
         amount: 4
@@ -2856,10 +2856,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       light_gray_dye:
         material: LIGHT_GRAY_DYE
         amount: 4
@@ -2874,10 +2874,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       cyan_dye:
         material: CYAN_DYE
         amount: 4
@@ -2892,10 +2892,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       purple_dye:
         material: PURPLE_DYE
         amount: 4
@@ -2910,10 +2910,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       blue_dye:
         material: BLUE_DYE
         amount: 4
@@ -2928,10 +2928,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       brown_dye:
         material: BROWN_DYE
         amount: 4
@@ -2946,10 +2946,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       green_dye:
         material: GREEN_DYE
         amount: 4
@@ -2964,10 +2964,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       red_dye:
         material: RED_DYE
         amount: 4
@@ -2982,10 +2982,10 @@ recipes:
     input:
       sand:
         material: SAND
-        amount: 32
+        amount: 18
       gravel:
         material: GRAVEL
-        amount: 32
+        amount: 24
       black_dye:
         material: BLACK_DYE
         amount: 4

--- a/templates/public/plugins/FactoryMod/config.yml.j2
+++ b/templates/public/plugins/FactoryMod/config.yml.j2
@@ -2718,7 +2718,7 @@ recipes:
         amount: 24
       white_dye:
         material: WHITE_DYE
-        amount: 4
+        amount: 2
     output:
       white_concrete:
         material: WHITE_CONCRETE_POWDER
@@ -2736,7 +2736,7 @@ recipes:
         amount: 24
       orange_dye:
         material: ORANGE_DYE
-        amount: 4
+        amount: 2
     output:
       orange_concrete:
         material: ORANGE_CONCRETE_POWDER
@@ -2754,7 +2754,7 @@ recipes:
         amount: 24
       magenta_dye:
         material: MAGENTA_DYE
-        amount: 4
+        amount: 2
     output:
       magenta_concrete:
         material: MAGENTA_CONCRETE_POWDER
@@ -2772,7 +2772,7 @@ recipes:
         amount: 24
       light_blue_dye:
         material: LIGHT_BLUE_DYE
-        amount: 4
+        amount: 2
     output:
       light_blue_concrete:
         material: LIGHT_BLUE_CONCRETE_POWDER
@@ -2790,7 +2790,7 @@ recipes:
         amount: 24
       yellow_dye:
         material: YELLOW_DYE
-        amount: 4
+        amount: 2
     output:
       yellow_concrete:
         material: YELLOW_CONCRETE_POWDER
@@ -2808,7 +2808,7 @@ recipes:
         amount: 24
       lime_dye:
         material: LIME_DYE
-        amount: 4
+        amount: 2
     output:
       lime_concrete:
         material: LIME_CONCRETE_POWDER
@@ -2826,7 +2826,7 @@ recipes:
         amount: 24
       pink_dye:
         material: PINK_DYE
-        amount: 4
+        amount: 2
     output:
       pink_concrete:
         material: PINK_CONCRETE_POWDER
@@ -2844,7 +2844,7 @@ recipes:
         amount: 24
       gray_dye:
         material: GRAY_DYE
-        amount: 4
+        amount: 2
     output:
       gray_concrete:
         material: GRAY_CONCRETE_POWDER
@@ -2862,7 +2862,7 @@ recipes:
         amount: 24
       light_gray_dye:
         material: LIGHT_GRAY_DYE
-        amount: 4
+        amount: 2
     output:
       light_gray_concrete:
         material: LIGHT_GRAY_CONCRETE_POWDER
@@ -2880,7 +2880,7 @@ recipes:
         amount: 24
       cyan_dye:
         material: CYAN_DYE
-        amount: 4
+        amount: 2
     output:
       cyan_concrete:
         material: CYAN_CONCRETE_POWDER
@@ -2898,7 +2898,7 @@ recipes:
         amount: 24
       purple_dye:
         material: PURPLE_DYE
-        amount: 4
+        amount: 2
     output:
       purple_concrete:
         material: PURPLE_CONCRETE_POWDER
@@ -2916,7 +2916,7 @@ recipes:
         amount: 24
       blue_dye:
         material: BLUE_DYE
-        amount: 4
+        amount: 2
     output:
       blue_concrete:
         material: BLUE_CONCRETE_POWDER
@@ -2934,7 +2934,7 @@ recipes:
         amount: 24
       brown_dye:
         material: BROWN_DYE
-        amount: 4
+        amount: 2
     output:
       brown_concrete:
         material: BROWN_CONCRETE_POWDER
@@ -2952,7 +2952,7 @@ recipes:
         amount: 24
       green_dye:
         material: GREEN_DYE
-        amount: 4
+        amount: 2
     output:
       green_concrete:
         material: GREEN_CONCRETE_POWDER
@@ -2970,7 +2970,7 @@ recipes:
         amount: 24
       red_dye:
         material: RED_DYE
-        amount: 4
+        amount: 2
     output:
       red_concrete:
         material: RED_CONCRETE_POWDER
@@ -2988,7 +2988,7 @@ recipes:
         amount: 24
       black_dye:
         material: BLACK_DYE
-        amount: 4
+        amount: 2
     output:
       black_concrete:
         material: BLACK_CONCRETE_POWDER


### PR DESCRIPTION
Concrete powder now takes 64 stone, 1 egg, and 4 dye, bringing it into the scale of materials used by recipes in the aesthetic factory.

There are now harden concrete recipes that convert concrete powder into concrete using 1 water bucket (refunding the bucket)

These changes are untested. I was about to go to sleep, but I did this instead. Errors are expected.