### PR TITLE
Obfuscate Terracotta to protect Mesa Biomes

### DIFF
--- a/templates/public/plugins/Orebfuscator/config.yml.j2
+++ b/templates/public/plugins/Orebfuscator/config.yml.j2
@@ -36,6 +36,13 @@ world:
   - minecraft:lapis_ore
   - minecraft:redstone_ore
   - minecraft:stone
+  - minecraft:terracotta
+  - minecraft:light_gray_terracotta
+  - minecraft:white_terracotta
+  - minecraft:orange_terracotta
+  - minecraft:red_terracotta
+  - minecraft:brown_terracotta
+  - minecraft:yellow_terracotta
   randomBlocks:
     minecraft:cave_air: 10
     minecraft:clay: 1


### PR DESCRIPTION
 Mesa cliffs aren't getting obfuscated as they aren't made of stone like normal terrain