### PR TITLE
Modify Bungee RAM

### DIFF
--- a/variables/all.yml
+++ b/variables/all.yml
@@ -27,10 +27,10 @@ mc_port: "{{ internal_port }}"
 bungee_port: "{{ external_port }}"
 
 #How much memory is used by the server
-shard_mem: 51G
+shard_mem: 49G
 
 #How much memory is used by bungee
-bungee_mem: 2048M
+bungee_mem: 4096M
 
 #Use PaperMC instead of Spigot?
 use_paper: false


### PR DESCRIPTION
Last time we had lag similar to this it turned out to be due to a lack of bungee having RAM, considering the increase in players (from 40-50, to 70-80) it could be possible that 2GB may no longer suffice? Why don't we just give it a shot to see if it might fix some of the network lag issues that players have been experiencing.