### PR TITLE
Fix "EMERALD" item identifier

### DIFF
--- a/templates/public/plugins/CraftEnhance/recipes.yml.j2
+++ b/templates/public/plugins/CraftEnhance/recipes.yml.j2
@@ -342,7 +342,7 @@ recipe19:
   shapeless: true
 recipe20:
   ==: com.dutchjelly.craftenhance.crafthandling.recipes.WBRecipe
-  result: EMERALD
+  result: EMERALD_1
   hidden: false
   recipe:
   - EXPERIENCE_BOTTLE_1


### PR DESCRIPTION
The proper identifier is "EMERALD_1" denoting the material and the amount. You can see it's usage in recipe19, and the identifier definition [here](https://github.com/CivClassic/AnsibleSetup/blob/4b2ce8d02c7e5da9e8fee6d73269cd772b4c8b92/templates/public/plugins/CraftEnhance/items.yml.j2#L143-L146)